### PR TITLE
Fix EasyAdmin GitLab downloads and SQLite session cleanup

### DIFF
--- a/src/runtime/addons.js
+++ b/src/runtime/addons.js
@@ -346,6 +346,41 @@ function pathExists(FS, path) {
   return FS.analyzePath(path)?.exists || false;
 }
 
+export function patchEasyAdminGitLabArchiveFallback(rawPhp) {
+  return String(rawPhp).replace(
+    /(\s+case 'gitlab\.com':\s+)(\$zip = \$url \. '\/repository\/archive\.zip';)(\s+break;)/u,
+    "$1// EasyAdmin builds an obsolete GitLab archive URL here. GitLab serves\n                    // public repository archives from the web archive route instead.\n                    $repoName = basename(parse_url($url, PHP_URL_PATH) ?: trim($url, '/'));\n                    $zip = rtrim($url, '/') . '/-/archive/master/' . $repoName . '-master.zip';$3",
+  );
+}
+
+export function patchEasyAdminSqliteSessionSupport(rawPhp) {
+  return String(rawPhp)
+    .replaceAll(
+      "'SHOW INDEX FROM `session` WHERE `column_name` = \"modified\";'",
+      "'SELECT 1'",
+    )
+    .replaceAll(
+      "DELETE `session` FROM `session` WHERE `modified` < :time;",
+      "DELETE FROM `session` WHERE `modified` < :time;",
+    )
+    .replace(
+      "$result = $this->connectionDbal->executeQuery(\"SHOW INDEX FROM `$table` WHERE `column_name` = '$column';\");\n        if (!$result->fetchOne()) {\n            try {\n                $this->connectionDbal->executeStatement(\"ALTER TABLE `$table` ADD INDEX `$column` (`$column`);\");\n            } catch (\\Exception $e) {\n                $this->logger->warn(\n                    'Unable to add index \"{column}\" in table \"{table}\" to improve performance: {msg}', // @translate\n                    ['column' => $column, 'table' => $table, 'msg' => $e->getMessage()]\n                );\n            }\n        }\n\n        $time = time();\n        $sql = 'DELETE FROM `session` WHERE `modified` < :time;';",
+      "$platform = $this->connectionDbal->getDatabasePlatform()->getName();\n        if ($platform !== 'sqlite') {\n            $result = $this->connectionDbal->executeQuery(\"SHOW INDEX FROM `$table` WHERE `column_name` = '$column';\");\n            if (!$result->fetchOne()) {\n                try {\n                    $this->connectionDbal->executeStatement(\"ALTER TABLE `$table` ADD INDEX `$column` (`$column`);\");\n                } catch (\\Exception $e) {\n                    $this->logger->warn(\n                        'Unable to add index \"{column}\" in table \"{table}\" to improve performance: {msg}', // @translate\n                        ['column' => $column, 'table' => $table, 'msg' => $e->getMessage()]\n                    );\n                }\n            }\n        }\n\n        $time = time();\n        $sql = 'DELETE FROM `session` WHERE `modified` < :time;';",
+    )
+    .replace(
+      "$dbname = $this->connection->getDatabase();\n        $sqlSize = <<<'SQL'\n            SELECT ROUND((data_length + index_length) / 1024 / 1024, 2)\n            FROM information_schema.TABLES\n            WHERE table_schema = ?\n                AND table_name = ?\n            SQL;\n        $size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
+      "$platform = $this->connection->getDatabasePlatform()->getName();\n        if ($platform === 'sqlite') {\n            $size = null;\n        } else {\n            $dbname = $this->connection->getDatabase();\n            $sqlSize = <<<'SQL'\n            SELECT ROUND((data_length + index_length) / 1024 / 1024, 2)\n            FROM information_schema.TABLES\n            WHERE table_schema = ?\n                AND table_name = ?\n            SQL;\n            $size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();\n        }",
+    )
+    .replace(
+      "        if ($recreate) {\n            $this->connection->executeStatement('SET foreign_key_checks = 0');\n            $this->connection->executeStatement('CREATE TABLE `session_new` LIKE `session`');\n            $this->connection->executeStatement('RENAME TABLE `session` TO `session_old`, `session_new` TO `session`');\n            $this->connection->executeStatement('DROP TABLE `session_old`');\n            $this->connection->executeStatement('SET foreign_key_checks = 1');\n            return;\n        }\n",
+      "        if ($recreate) {\n            if ($platform === 'sqlite') {\n                $this->logger->warn(\n                    'Session table recreation is not supported on SQLite.' // @translate\n                );\n                return;\n            }\n            $this->connection->executeStatement('SET foreign_key_checks = 0');\n            $this->connection->executeStatement('CREATE TABLE `session_new` LIKE `session`');\n            $this->connection->executeStatement('RENAME TABLE `session` TO `session_old`, `session_new` TO `session`');\n            $this->connection->executeStatement('DROP TABLE `session_old`');\n            $this->connection->executeStatement('SET foreign_key_checks = 1');\n            return;\n        }\n",
+    )
+    .replace(
+      "$size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
+      "$size = $platform === 'sqlite'\n                ? null\n                : $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
+    );
+}
+
 async function prepareEasyAdminCatalogCache(FS, persistedPath, proxyBaseUrl) {
   for (const source of EASY_ADMIN_REMOTE_SOURCES) {
     const targetPath = `${persistedPath}/${source.relativePath}`.replace(
@@ -419,6 +454,8 @@ async function patchEasyAdminAddon(FS, persistedPath, proxyBaseUrl) {
       "    protected function fileGetContents($url): ?string\n    {\n        $uri = new HttpUri($url);\n        $this->httpClient->reset();\n        $this->httpClient->setUri($uri);\n        try {\n            $response = $this->httpClient->send();\n            $response = $response->isOk() ? $response->getBody() : null;\n        } catch (RuntimeException $e) {\n            $response = null;\n        }\n",
       "    protected function fileGetContents($url): ?string\n    {\n        if (!preg_match('~^https?://~i', (string) $url)) {\n            $response = @file_get_contents($url) ?: null;\n        } else {\n            $uri = new HttpUri($url);\n            $this->httpClient->reset();\n            $this->httpClient->setUri($uri);\n            try {\n                $response = $this->httpClient->send();\n                $response = $response->isOk() ? $response->getBody() : null;\n            } catch (RuntimeException $e) {\n                $response = null;\n            }\n        }\n",
     );
+    raw = patchEasyAdminGitLabArchiveFallback(raw);
+    raw = patchEasyAdminSqliteSessionSupport(raw);
 
     FS.writeFile(addonPluginPath, raw, { encoding: "utf8" });
   }
@@ -434,6 +471,36 @@ async function patchEasyAdminAddon(FS, persistedPath, proxyBaseUrl) {
       `@file_get_contents(${moduleCacheRoot} . '/omeka_s_selections.csv')`,
     );
     FS.writeFile(addonsFormFactoryPath, raw, { encoding: "utf8" });
+  }
+
+  const cronTasksPath = `${persistedPath}/src/Job/CronTasks.php`.replace(
+    /\/{2,}/gu,
+    "/",
+  );
+  if (pathExists(FS, cronTasksPath)) {
+    const raw = patchEasyAdminSqliteSessionSupport(
+      FS.readFile(cronTasksPath, { encoding: "utf8" }),
+    );
+    FS.writeFile(cronTasksPath, raw, { encoding: "utf8" });
+  }
+
+  const dbSessionPath = `${persistedPath}/src/Job/DbSession.php`.replace(
+    /\/{2,}/gu,
+    "/",
+  );
+  if (pathExists(FS, dbSessionPath)) {
+    const raw = patchEasyAdminSqliteSessionSupport(
+      FS.readFile(dbSessionPath, { encoding: "utf8" }),
+    );
+    FS.writeFile(dbSessionPath, raw, { encoding: "utf8" });
+  }
+
+  const modulePhpPath = `${persistedPath}/Module.php`.replace(/\/{2,}/gu, "/");
+  if (pathExists(FS, modulePhpPath)) {
+    const raw = patchEasyAdminSqliteSessionSupport(
+      FS.readFile(modulePhpPath, { encoding: "utf8" }),
+    );
+    FS.writeFile(modulePhpPath, raw, { encoding: "utf8" });
   }
 }
 

--- a/src/runtime/addons.js
+++ b/src/runtime/addons.js
@@ -1,4 +1,8 @@
 import { unzipSync } from "../../vendor/fflate/esm/browser.js";
+import {
+  patchEasyAdminGitLabArchiveFallback,
+  patchEasyAdminSqliteSessionSupport,
+} from "./easyadmin-patches.js";
 import { APP_LOCATION, resolveProxyUrl } from "./networking.js";
 
 export const PERSIST_ADDONS_ROOT = "/persist/addons";
@@ -344,41 +348,6 @@ function writeArchiveToFs(FS, targetDir, zipBytes) {
 
 function pathExists(FS, path) {
   return FS.analyzePath(path)?.exists || false;
-}
-
-export function patchEasyAdminGitLabArchiveFallback(rawPhp) {
-  return String(rawPhp).replace(
-    /(\s+case 'gitlab\.com':\s+)(\$zip = \$url \. '\/repository\/archive\.zip';)(\s+break;)/u,
-    "$1// EasyAdmin builds an obsolete GitLab archive URL here. GitLab serves\n                    // public repository archives from the web archive route instead.\n                    $repoName = basename(parse_url($url, PHP_URL_PATH) ?: trim($url, '/'));\n                    $zip = rtrim($url, '/') . '/-/archive/master/' . $repoName . '-master.zip';$3",
-  );
-}
-
-export function patchEasyAdminSqliteSessionSupport(rawPhp) {
-  return String(rawPhp)
-    .replaceAll(
-      "'SHOW INDEX FROM `session` WHERE `column_name` = \"modified\";'",
-      "'SELECT 1'",
-    )
-    .replaceAll(
-      "DELETE `session` FROM `session` WHERE `modified` < :time;",
-      "DELETE FROM `session` WHERE `modified` < :time;",
-    )
-    .replace(
-      "$result = $this->connectionDbal->executeQuery(\"SHOW INDEX FROM `$table` WHERE `column_name` = '$column';\");\n        if (!$result->fetchOne()) {\n            try {\n                $this->connectionDbal->executeStatement(\"ALTER TABLE `$table` ADD INDEX `$column` (`$column`);\");\n            } catch (\\Exception $e) {\n                $this->logger->warn(\n                    'Unable to add index \"{column}\" in table \"{table}\" to improve performance: {msg}', // @translate\n                    ['column' => $column, 'table' => $table, 'msg' => $e->getMessage()]\n                );\n            }\n        }\n\n        $time = time();\n        $sql = 'DELETE FROM `session` WHERE `modified` < :time;';",
-      "$platform = $this->connectionDbal->getDatabasePlatform()->getName();\n        if ($platform !== 'sqlite') {\n            $result = $this->connectionDbal->executeQuery(\"SHOW INDEX FROM `$table` WHERE `column_name` = '$column';\");\n            if (!$result->fetchOne()) {\n                try {\n                    $this->connectionDbal->executeStatement(\"ALTER TABLE `$table` ADD INDEX `$column` (`$column`);\");\n                } catch (\\Exception $e) {\n                    $this->logger->warn(\n                        'Unable to add index \"{column}\" in table \"{table}\" to improve performance: {msg}', // @translate\n                        ['column' => $column, 'table' => $table, 'msg' => $e->getMessage()]\n                    );\n                }\n            }\n        }\n\n        $time = time();\n        $sql = 'DELETE FROM `session` WHERE `modified` < :time;';",
-    )
-    .replace(
-      "$dbname = $this->connection->getDatabase();\n        $sqlSize = <<<'SQL'\n            SELECT ROUND((data_length + index_length) / 1024 / 1024, 2)\n            FROM information_schema.TABLES\n            WHERE table_schema = ?\n                AND table_name = ?\n            SQL;\n        $size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
-      "$platform = $this->connection->getDatabasePlatform()->getName();\n        if ($platform === 'sqlite') {\n            $size = null;\n        } else {\n            $dbname = $this->connection->getDatabase();\n            $sqlSize = <<<'SQL'\n            SELECT ROUND((data_length + index_length) / 1024 / 1024, 2)\n            FROM information_schema.TABLES\n            WHERE table_schema = ?\n                AND table_name = ?\n            SQL;\n            $size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();\n        }",
-    )
-    .replace(
-      "        if ($recreate) {\n            $this->connection->executeStatement('SET foreign_key_checks = 0');\n            $this->connection->executeStatement('CREATE TABLE `session_new` LIKE `session`');\n            $this->connection->executeStatement('RENAME TABLE `session` TO `session_old`, `session_new` TO `session`');\n            $this->connection->executeStatement('DROP TABLE `session_old`');\n            $this->connection->executeStatement('SET foreign_key_checks = 1');\n            return;\n        }\n",
-      "        if ($recreate) {\n            if ($platform === 'sqlite') {\n                $this->logger->warn(\n                    'Session table recreation is not supported on SQLite.' // @translate\n                );\n                return;\n            }\n            $this->connection->executeStatement('SET foreign_key_checks = 0');\n            $this->connection->executeStatement('CREATE TABLE `session_new` LIKE `session`');\n            $this->connection->executeStatement('RENAME TABLE `session` TO `session_old`, `session_new` TO `session`');\n            $this->connection->executeStatement('DROP TABLE `session_old`');\n            $this->connection->executeStatement('SET foreign_key_checks = 1');\n            return;\n        }\n",
-    )
-    .replace(
-      "$size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
-      "$size = $platform === 'sqlite'\n                ? null\n                : $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
-    );
 }
 
 async function prepareEasyAdminCatalogCache(FS, persistedPath, proxyBaseUrl) {

--- a/src/runtime/easyadmin-patches.js
+++ b/src/runtime/easyadmin-patches.js
@@ -1,0 +1,34 @@
+export function patchEasyAdminGitLabArchiveFallback(rawPhp) {
+  return String(rawPhp).replace(
+    /(\s+case 'gitlab\.com':\s+)(\$zip = \$url \. '\/repository\/archive\.zip';)(\s+break;)/u,
+    "$1// EasyAdmin builds an obsolete GitLab archive URL here. GitLab serves\n                    // public repository archives from the web archive route instead.\n                    $repoName = basename(parse_url($url, PHP_URL_PATH) ?: trim($url, '/'));\n                    $zip = rtrim($url, '/') . '/-/archive/master/' . $repoName . '-master.zip';$3",
+  );
+}
+
+export function patchEasyAdminSqliteSessionSupport(rawPhp) {
+  return String(rawPhp)
+    .replaceAll(
+      "'SHOW INDEX FROM `session` WHERE `column_name` = \"modified\";'",
+      "'SELECT 1'",
+    )
+    .replaceAll(
+      "DELETE `session` FROM `session` WHERE `modified` < :time;",
+      "DELETE FROM `session` WHERE `modified` < :time;",
+    )
+    .replace(
+      "$result = $this->connectionDbal->executeQuery(\"SHOW INDEX FROM `$table` WHERE `column_name` = '$column';\");\n        if (!$result->fetchOne()) {\n            try {\n                $this->connectionDbal->executeStatement(\"ALTER TABLE `$table` ADD INDEX `$column` (`$column`);\");\n            } catch (\\Exception $e) {\n                $this->logger->warn(\n                    'Unable to add index \"{column}\" in table \"{table}\" to improve performance: {msg}', // @translate\n                    ['column' => $column, 'table' => $table, 'msg' => $e->getMessage()]\n                );\n            }\n        }\n\n        $time = time();\n        $sql = 'DELETE FROM `session` WHERE `modified` < :time;';",
+      "$platform = $this->connectionDbal->getDatabasePlatform()->getName();\n        if ($platform !== 'sqlite') {\n            $result = $this->connectionDbal->executeQuery(\"SHOW INDEX FROM `$table` WHERE `column_name` = '$column';\");\n            if (!$result->fetchOne()) {\n                try {\n                    $this->connectionDbal->executeStatement(\"ALTER TABLE `$table` ADD INDEX `$column` (`$column`);\");\n                } catch (\\Exception $e) {\n                    $this->logger->warn(\n                        'Unable to add index \"{column}\" in table \"{table}\" to improve performance: {msg}', // @translate\n                        ['column' => $column, 'table' => $table, 'msg' => $e->getMessage()]\n                    );\n                }\n            }\n        }\n\n        $time = time();\n        $sql = 'DELETE FROM `session` WHERE `modified` < :time;';",
+    )
+    .replace(
+      "$dbname = $this->connection->getDatabase();\n        $sqlSize = <<<'SQL'\n            SELECT ROUND((data_length + index_length) / 1024 / 1024, 2)\n            FROM information_schema.TABLES\n            WHERE table_schema = ?\n                AND table_name = ?\n            SQL;\n        $size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
+      "$platform = $this->connection->getDatabasePlatform()->getName();\n        if ($platform === 'sqlite') {\n            $size = null;\n        } else {\n            $dbname = $this->connection->getDatabase();\n            $sqlSize = <<<'SQL'\n            SELECT ROUND((data_length + index_length) / 1024 / 1024, 2)\n            FROM information_schema.TABLES\n            WHERE table_schema = ?\n                AND table_name = ?\n            SQL;\n            $size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();\n        }",
+    )
+    .replace(
+      "        if ($recreate) {\n            $this->connection->executeStatement('SET foreign_key_checks = 0');\n            $this->connection->executeStatement('CREATE TABLE `session_new` LIKE `session`');\n            $this->connection->executeStatement('RENAME TABLE `session` TO `session_old`, `session_new` TO `session`');\n            $this->connection->executeStatement('DROP TABLE `session_old`');\n            $this->connection->executeStatement('SET foreign_key_checks = 1');\n            return;\n        }\n",
+      "        if ($recreate) {\n            if ($platform === 'sqlite') {\n                $this->logger->warn(\n                    'Session table recreation is not supported on SQLite.' // @translate\n                );\n                return;\n            }\n            $this->connection->executeStatement('SET foreign_key_checks = 0');\n            $this->connection->executeStatement('CREATE TABLE `session_new` LIKE `session`');\n            $this->connection->executeStatement('RENAME TABLE `session` TO `session_old`, `session_new` TO `session`');\n            $this->connection->executeStatement('DROP TABLE `session_old`');\n            $this->connection->executeStatement('SET foreign_key_checks = 1');\n            return;\n        }\n",
+    )
+    .replace(
+      "$size = $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
+      "$size = $platform === 'sqlite'\n                ? null\n                : $this->connection->executeQuery($sqlSize, [$dbname, $this->table])->fetchOne();",
+    );
+}

--- a/tests/addons.test.mjs
+++ b/tests/addons.test.mjs
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import {
   patchEasyAdminGitLabArchiveFallback,
   patchEasyAdminSqliteSessionSupport,
-} from "../src/runtime/addons.js";
+} from "../src/runtime/easyadmin-patches.js";
 import { parseGitHubArchiveUrl } from "../src/shared/github.js";
 
 describe("parseGitHubArchiveUrl", () => {

--- a/tests/addons.test.mjs
+++ b/tests/addons.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import {
+  patchEasyAdminGitLabArchiveFallback,
+  patchEasyAdminSqliteSessionSupport,
+} from "../src/runtime/addons.js";
 import { parseGitHubArchiveUrl } from "../src/shared/github.js";
 
 describe("parseGitHubArchiveUrl", () => {
@@ -40,6 +44,62 @@ describe("parseGitHubArchiveUrl", () => {
     assert.equal(
       parseGitHubArchiveUrl("https://example.com/downloads/addon.zip"),
       null,
+    );
+  });
+});
+
+describe("patchEasyAdminGitLabArchiveFallback", () => {
+  it("rewrites the obsolete GitLab archive fallback used by EasyAdmin", () => {
+    const original = `                case 'gitlab.com':
+                    $zip = $url . '/repository/archive.zip';
+                    break;`;
+
+    const patched = patchEasyAdminGitLabArchiveFallback(original);
+
+    assert.match(patched, /GitLab serves/u);
+    assert.match(
+      patched,
+      /\$zip = rtrim\(\$url, '\/'\) \. '\/-\/archive\/master\/' \. \$repoName \. '-master\.zip';/u,
+    );
+    assert.doesNotMatch(patched, /repository\/archive\.zip/u);
+  });
+});
+
+describe("patchEasyAdminSqliteSessionSupport", () => {
+  it("replaces MySQL-specific session cleanup SQL with SQLite-safe fallbacks", () => {
+    const original = `
+        $result = $this->connection->executeQuery(
+            'SHOW INDEX FROM \`session\` WHERE \`column_name\` = "modified";'
+        );
+
+        $result = $this->connectionDbal->executeQuery("SHOW INDEX FROM \`$table\` WHERE \`column_name\` = '$column';");
+        if (!$result->fetchOne()) {
+            try {
+                $this->connectionDbal->executeStatement("ALTER TABLE \`$table\` ADD INDEX \`$column\` (\`$column\`);");
+            } catch (\\Exception $e) {
+                $this->logger->warn(
+                    'Unable to add index "{column}" in table "{table}" to improve performance: {msg}', // @translate
+                    ['column' => $column, 'table' => $table, 'msg' => $e->getMessage()]
+                );
+            }
+        }
+
+        $time = time();
+        $sql = 'DELETE \`session\` FROM \`session\` WHERE \`modified\` < :time;';
+    `;
+
+    const patched = patchEasyAdminSqliteSessionSupport(original);
+
+    assert.doesNotMatch(
+      patched,
+      /'SHOW INDEX FROM `session` WHERE `column_name` = "modified";'/u,
+    );
+    assert.match(patched, /SELECT 1/u);
+    assert.doesNotMatch(patched, /DELETE `session` FROM `session`/u);
+    assert.match(patched, /DELETE FROM `session` WHERE `modified` < :time;/u);
+    assert.match(
+      patched,
+      /\$platform = \$this->connectionDbal->getDatabasePlatform\(\)->getName\(\);/u,
     );
   });
 });


### PR DESCRIPTION
## Summary
- patch EasyAdmin's GitLab fallback archive URL to use a valid GitLab archive path
- patch EasyAdmin session cleanup tasks for SQLite by avoiding MySQL-only SQL
- add regression tests for both EasyAdmin compatibility patches

## Testing
- `node --test tests/addons.test.mjs`
- `make lint`
- `make test`