### PR TITLE
Dedupe @php-wasm/universal to fix "Runtime with id 1 not found"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "omeka-s-playground",
       "dependencies": {
         "@php-wasm/universal": "^3.1.20",
-        "@php-wasm/web": "^3.1.19",
+        "@php-wasm/web": "^3.1.20",
         "fflate": "^0.8.2"
       },
       "devDependencies": {
@@ -84,6 +84,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -101,6 +104,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -118,6 +124,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -135,6 +144,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -621,9 +633,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -1146,12 +1158,12 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/cli-util": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.19.tgz",
-      "integrity": "sha512-an7O1u7Tv54YR9+kw5fT32Zataa7gQ9f71ZdSBqvEk53j6QQZ6bvpgXbyFk0WUrnVzO9ABINZnbPozNEwrlMQg==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.20.tgz",
+      "integrity": "sha512-zO02i+SpPUF/3O9/JEAmideDiwICzGcoCKssleavwv9sDRr9j7nIokuG9u97T37QgrHX0sap9BGTzZ9C6cgG6w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.19",
+        "@php-wasm/util": "3.1.20",
         "fast-xml-parser": "^5.5.1",
         "jsonc-parser": "3.3.1"
       },
@@ -1161,22 +1173,22 @@
       }
     },
     "node_modules/@php-wasm/fs-journal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.19.tgz",
-      "integrity": "sha512-Y7qPxqj0F7mQzST9fqgpfzpcl4Dgyo1FuwzJyAhYLWSvsoMNYruQ90MaG0zDL6lySptjmGmQYbYk8oUcTe7SXQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.20.tgz",
+      "integrity": "sha512-TvS5YjYi9GiZOC8GISgEzn0Or2Lk2WzdL/7U+1w9LkmbhUuznJmkYYWFcrct4PKimIaw13Ov+dOI3ens4DL5QA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node": "3.1.19",
-        "@php-wasm/universal": "3.1.19",
-        "@php-wasm/util": "3.1.19",
+        "@php-wasm/logger": "3.1.20",
+        "@php-wasm/node": "3.1.20",
+        "@php-wasm/universal": "3.1.20",
+        "@php-wasm/util": "3.1.20",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",
         "ini": "4.1.2",
         "jsonc-parser": "3.3.1",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
+        "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
@@ -1184,77 +1196,41 @@
         "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/fs-journal/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/fs-journal/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.19.tgz",
-      "integrity": "sha512-CEev6BvRg/IigVkmhsisNp69HOXZWvHMFJSwYZcSCkEnt0+4QvzxVQNP4Udtt9nmjo8BNCU3ki1JWJfaegKZgA==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.20.tgz",
+      "integrity": "sha512-uewkiBJKohKTqcUT3oyi+ijwhW4DiSP9E1wqXdMbIwfFw3ZKKQWuqS0+TsLMt6imR6wTir1jwZwacizVjE6Lcg==",
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/node": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.19.tgz",
-      "integrity": "sha512-9b4eJL+Dwe9LATchgaBpnq3MaReG09IliF0HgCTd3DhWQCNpASyxWN8dU7QwRIfpomf9K5BxboLj51Crjv+ZaA==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.20.tgz",
+      "integrity": "sha512-g1MoBRBit223c3s9WFw6mj0StIfxI7joIwRn1q8lZZCaxRTJ3lTKSsK4IPrXGQcGBPHu+cYWzJ+xiFdGwKmmkw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/cli-util": "3.1.19",
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-7-4": "3.1.19",
-        "@php-wasm/node-8-0": "3.1.19",
-        "@php-wasm/node-8-1": "3.1.19",
-        "@php-wasm/node-8-2": "3.1.19",
-        "@php-wasm/node-8-3": "3.1.19",
-        "@php-wasm/node-8-4": "3.1.19",
-        "@php-wasm/node-8-5": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/universal": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "@wp-playground/common": "3.1.19",
+        "@php-wasm/cli-util": "3.1.20",
+        "@php-wasm/logger": "3.1.20",
+        "@php-wasm/node-7-4": "3.1.20",
+        "@php-wasm/node-8-0": "3.1.20",
+        "@php-wasm/node-8-1": "3.1.20",
+        "@php-wasm/node-8-2": "3.1.20",
+        "@php-wasm/node-8-3": "3.1.20",
+        "@php-wasm/node-8-4": "3.1.20",
+        "@php-wasm/node-8-5": "3.1.20",
+        "@php-wasm/universal": "3.1.20",
+        "@php-wasm/util": "3.1.20",
+        "@wp-playground/common": "3.1.20",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",
         "ini": "4.1.2",
         "jsonc-parser": "3.3.1",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
+        "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
@@ -1263,47 +1239,15 @@
       }
     },
     "node_modules/@php-wasm/node-7-4": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.19.tgz",
-      "integrity": "sha512-fPIVoOp1iOWX8J2Z0Nz+HxkzABrvT2sKlAb4Iumx0CENXa6hR2C2n+bWBrasiKUUSB51GYXrvE/n/hCETAiYSQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.20.tgz",
+      "integrity": "sha512-SMSuSBpIERYb7GN5YbePLJjjqClys5jIQrO+s8tJJj2VLkEDzHlyS5CmYWsvkynbzAz5FEBOWtYoVTlVhWzLKw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-7-4/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-7-4/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
+        "ws": "8.18.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1311,47 +1255,15 @@
       }
     },
     "node_modules/@php-wasm/node-8-0": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.19.tgz",
-      "integrity": "sha512-ESkAEDPsheJGPYC3+dSri5hBAJkP80YAM4MSkTrJVsiXBNr8bH/I4IgSGuNE2Fcw6z9Yu8dC2mjupE7aSUZQ/A==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.20.tgz",
+      "integrity": "sha512-6SdYDZUupzLwMMf/wI+B02H+a9mQcB3tKUuAyVHRz3SzPo3AQcHJCUlASR7G1sP+mQ+F6D6kOTwQdIfgtfcNHA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-0/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-0/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
+        "ws": "8.18.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1359,47 +1271,15 @@
       }
     },
     "node_modules/@php-wasm/node-8-1": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.19.tgz",
-      "integrity": "sha512-ZfEiba6OhNPlDVUvBc9cZlImgrKsfApEMU2Xp4TEe6BQZsXNesxMNdg0ny936EiALI5gYMrqC72p4Nqe4ZVeJA==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.20.tgz",
+      "integrity": "sha512-DURvgZLVkDBst+KF/O34A8SM9zdHXKUgafQzc2udxa4uOM+oQ8MHdx9UMOPI9O+T7vSIzDBWHRCwoCHQGa4Cmg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-1/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-1/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
+        "ws": "8.18.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1407,47 +1287,15 @@
       }
     },
     "node_modules/@php-wasm/node-8-2": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.19.tgz",
-      "integrity": "sha512-+sE+Wl2jIgFalb5yKB7cmB6LRPZh4V6axEAuCrrob/nwrjhC9WFSjwUcVRX6ivEhW76wtSQKUg2dNfRnsChbGQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.20.tgz",
+      "integrity": "sha512-ov2r4ZvKAoDa2EdgNo3+jgA0XRwTt08AG8iRsMaqlFBuhCgr7NdaKjonXwoHIg41hfntL/y5cNL4iZlv85eMaw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-2/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-2/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
+        "ws": "8.18.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1455,47 +1303,15 @@
       }
     },
     "node_modules/@php-wasm/node-8-3": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.19.tgz",
-      "integrity": "sha512-LwAZQu/5joqfiDhMDVsNiKIwl1vY3ljyV6tRWh0F4Uhm6ghO+DPjIHG/t2dRss1Swq8za8fh1ugMbEH40GWazQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.20.tgz",
+      "integrity": "sha512-d44tJF0PhuQQEt8svtwOnryqnUTyUchsUGziTzw1aaN5C+/pJF3D5L7Gmu9PQn0RXyZua9fpMzuWrIfuWGCiHQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-3/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-3/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
+        "ws": "8.18.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1503,47 +1319,15 @@
       }
     },
     "node_modules/@php-wasm/node-8-4": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.19.tgz",
-      "integrity": "sha512-+YO2J8H/QVA0VMZqNLLfvDP9AF9JB0Upw41vWigo1B3ANON7GpriQxp1BScjH+7KYJYOOOSQsU58fDYEb+f10g==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.20.tgz",
+      "integrity": "sha512-f6JjuMdkE3SmK78kqkzXX38tiKKdgeuu/nmpQkUgHDcsnVfwtpgsF23o9XBqIGmkmFOAQ4fivn2oYS+ar/EU+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-4/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-4/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
+        "ws": "8.18.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1551,85 +1335,15 @@
       }
     },
     "node_modules/@php-wasm/node-8-5": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.19.tgz",
-      "integrity": "sha512-+CuRTidTIUGSPej35jUWPSAMAs77Lo5lzv7RG/sNd+l7QacYCJUzW+cY2vHKBoKEYqgDO1RZkyvn4AuypwpPgQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.20.tgz",
+      "integrity": "sha512-6GLFSHEzCIFhKWm77bx6fI4+ffxwLh+zQO4U7TNLmU3ZW2Yb6LnsTXn+uWAv6tqUVk5+bXQRgF4bPUd+Jksf1Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-5/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-5/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-polyfills": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.19.tgz",
-      "integrity": "sha512-+6Wj2HTlegbufEhSz5cP2u4f5MD5k+hu6bWIdgJm57rkcIRhb1ykMGihjAkFCiXOvRhLhzy5umHmSBcrNSXZpg==",
-      "license": "GPL-2.0-or-later"
-    },
-    "node_modules/@php-wasm/node/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
+        "ws": "8.18.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1649,20 +1363,10 @@
         "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/progress/node_modules/@php-wasm/logger": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.20.tgz",
-      "integrity": "sha512-uewkiBJKohKTqcUT3oyi+ijwhW4DiSP9E1wqXdMbIwfFw3ZKKQWuqS0+TsLMt6imR6wTir1jwZwacizVjE6Lcg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.19.tgz",
-      "integrity": "sha512-f9z+1JU1yVd4QoiG/1uDiwcLYyjEYpzSNEx5Bnv5a93RZ0+SPjgLLxshN9C2N1R7Ko5N/FdCUvgMGterjZA/rw==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.20.tgz",
+      "integrity": "sha512-ia5Vdb8vcqDauewjJJTzklmBgnmxNi5NjUOGltAWzOveecfj8H8v+gdgX4/CDryCgu92EYhCu/Ko1a3x7eO5Vg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -1670,13 +1374,12 @@
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.19.tgz",
-      "integrity": "sha512-DA50ttOjyQA/rhf54pbGhUwNzsg9m1y8wzPVK2lxuNZaDqAcMNMNDV7uMo5+WGh3nDFvwYuUwIgF9z//+m2Y+w==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.20.tgz",
+      "integrity": "sha512-nAOA7wb0GKtMD2kcgVworVT5wrgmfSS3b5cacM0YUPb4z2uHhmBjhBQTQKVkTc1p3BrzUQpILqrnxVsRVuahNQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/util": "3.1.19"
+        "@php-wasm/util": "3.1.20"
       }
     },
     "node_modules/@php-wasm/universal": {
@@ -1696,26 +1399,7 @@
         "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/universal/node_modules/@php-wasm/logger": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.20.tgz",
-      "integrity": "sha512-uewkiBJKohKTqcUT3oyi+ijwhW4DiSP9E1wqXdMbIwfFw3ZKKQWuqS0+TsLMt6imR6wTir1jwZwacizVjE6Lcg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/universal/node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.20.tgz",
-      "integrity": "sha512-nAOA7wb0GKtMD2kcgVworVT5wrgmfSS3b5cacM0YUPb4z2uHhmBjhBQTQKVkTc1p3BrzUQpILqrnxVsRVuahNQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/util": "3.1.20"
-      }
-    },
-    "node_modules/@php-wasm/universal/node_modules/@php-wasm/util": {
+    "node_modules/@php-wasm/util": {
       "version": "3.1.20",
       "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.20.tgz",
       "integrity": "sha512-5Ad14Y6BO38bWzvSdYvmljREY7iVlkEp9auzh8KtQ8OeymQPvzAafdHuS0dsO5Cv61KC01LQfMZzhn9QlDIeJg==",
@@ -1724,35 +1408,26 @@
         "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/util": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.19.tgz",
-      "integrity": "sha512-W+oy4rp7vaupR5KeRrgEJJ2D2ebDIIdhmZsq1pts9CC1iVLxkvOtVDSluaeOvjTT+MYJDAuEu4uImhlI6tLfiA==",
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/@php-wasm/web": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.19.tgz",
-      "integrity": "sha512-p2KE7bMpT6IMLXvzy45Z3Kvhca3p8Ghcr1vfJLLGEBunE1XYjHiM2SMqKhFCmgg6P1+i9qr77x0C03Pm/pPkGQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.20.tgz",
+      "integrity": "sha512-RFnhS3LxS6Ftkhm2P21011zMA9uF6ntyVhd+b3D/S0ZU2Vnw1AtDixrvo6hNRqUodS7dqEppRR3P57t+lAaHVA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/fs-journal": "3.1.19",
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/universal": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "@php-wasm/web-7-4": "3.1.19",
-        "@php-wasm/web-8-0": "3.1.19",
-        "@php-wasm/web-8-1": "3.1.19",
-        "@php-wasm/web-8-2": "3.1.19",
-        "@php-wasm/web-8-3": "3.1.19",
-        "@php-wasm/web-8-4": "3.1.19",
-        "@php-wasm/web-8-5": "3.1.19",
-        "@php-wasm/web-service-worker": "3.1.19",
-        "@wp-playground/common": "3.1.19",
-        "@wp-playground/storage": "3.1.19",
+        "@php-wasm/fs-journal": "3.1.20",
+        "@php-wasm/logger": "3.1.20",
+        "@php-wasm/universal": "3.1.20",
+        "@php-wasm/util": "3.1.20",
+        "@php-wasm/web-7-4": "3.1.20",
+        "@php-wasm/web-8-0": "3.1.20",
+        "@php-wasm/web-8-1": "3.1.20",
+        "@php-wasm/web-8-2": "3.1.20",
+        "@php-wasm/web-8-3": "3.1.20",
+        "@php-wasm/web-8-4": "3.1.20",
+        "@php-wasm/web-8-5": "3.1.20",
+        "@php-wasm/web-service-worker": "3.1.20",
+        "@wp-playground/common": "3.1.20",
+        "@wp-playground/storage": "3.1.20",
         "@zip.js/zip.js": "2.7.57",
         "async-lock": "1.4.1",
         "clean-git-ref": "2.0.1",
@@ -1772,7 +1447,7 @@
         "sha.js": "2.4.12",
         "simple-get": "4.0.1",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
+        "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
@@ -1781,46 +1456,14 @@
       }
     },
     "node_modules/@php-wasm/web-7-4": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.19.tgz",
-      "integrity": "sha512-y/DHzU+LB2alK7r7jm74Dci/JPwjmej3+S9FfCg9aWoSRCvQ5LkcImjWJxCbYllKElnZJwm9KhZe+EW6Z7gmCQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.20.tgz",
+      "integrity": "sha512-Li9IeKZoiozrfqMw8vMD/HjQsefNjp7vHBKUC1WnnedIyItZJXfsYkFm9pjRaa+s98wXzPQGZNnEXdwlyKwBiw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-7-4/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-7-4/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1828,46 +1471,14 @@
       }
     },
     "node_modules/@php-wasm/web-8-0": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.19.tgz",
-      "integrity": "sha512-SBxp6kIsYi3VmZXAaoJlr7OtAm7paKsLpwuo0T5SGvq9ZtDvzk14dcV53/9eaCVKFnqEGvLYEUwzR26A/ij6hw==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.20.tgz",
+      "integrity": "sha512-g0OPSuxerd2bwCcHGdgA2SlPkZF9dtSRoThCfgFtiDQzeU+WPmWWO+CnJ1o4mslpP/bN4+Jhfbc4ufRYehLfNQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-0/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-0/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1875,46 +1486,14 @@
       }
     },
     "node_modules/@php-wasm/web-8-1": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.19.tgz",
-      "integrity": "sha512-YnstlRtpU9wZBn2+he0bQjYJ0v3M5j6Y84N6InfcDI033gqvkxKKLbYHOvJrMMp5TkrCdEcRhY3CUI6ZOhm1pw==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.20.tgz",
+      "integrity": "sha512-0nhuXzruPAp77mQXBle2O8QBxa5WUEkADw5//j5a2v9FHkD+uGChBD7/Tl6KlfZkI2ha4phyM97Ru/Qx+OREjg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-1/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-1/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1922,46 +1501,14 @@
       }
     },
     "node_modules/@php-wasm/web-8-2": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.19.tgz",
-      "integrity": "sha512-R/e3G0HYN3RB7K1XS9So1VuH+lXO7K3Fqe21+2iPfKlgrR1a10mwp/b9P6XdZSN/sniR2o6jzdN1Re/E9wuoKA==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.20.tgz",
+      "integrity": "sha512-i+8mi0udxhA00LVV00GKvY7YajNNnzYc1tmNTvAbJ5GJ3xmXAa863vVIZrMSQr3uQqM+Cxugef+sk0BwtxR0Lw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-2/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-2/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1969,46 +1516,14 @@
       }
     },
     "node_modules/@php-wasm/web-8-3": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.19.tgz",
-      "integrity": "sha512-nWi+8H0f+KisZfc9t5ZsmT0Jq4voq1bRhWpMmEopJC85ZCvPUHoMe13TSP+HNWRnwJniwnUb+bJ138yIAPFtIw==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.20.tgz",
+      "integrity": "sha512-IrZkCMpl1TkK5JBxmS03gun0+x6V6YeFXiGhJPYFFdv1JU8vIZdoMUnOMinaccohqxHByCA+0EkaaeQQc51yOg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-3/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-3/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -2016,46 +1531,14 @@
       }
     },
     "node_modules/@php-wasm/web-8-4": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.19.tgz",
-      "integrity": "sha512-tW4iC9VZGgNrR6+i5/wskhDXrKnlwmFZuT3KZ8Dtxk4s2gr/4g5Gr8VporLTalnrEEhgpVf6SiKUeV0l9xEpDQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.20.tgz",
+      "integrity": "sha512-FFEMfn9XCIf67z8gOTC4njv3hT/SfRNWNYUgieb0yMklvro5BjusrqWe47oQ9DP24SSBFG+XYmYYZvmDn1jOWA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-4/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-4/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -2063,12 +1546,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-5": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.19.tgz",
-      "integrity": "sha512-tIt0zXu1YRMcm7Vs6hsKWqrGGj3WDMyEH6QzclAsT7pNVJ+tbFx8wvVjCr6lUlfb9KxK1ZrBkEqu5mRqx4ytsw==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.20.tgz",
+      "integrity": "sha512-Ex1X3ZDWrJ0WBhG8iqLsPPVZVkxeoVcXnIhIbLV5lJ3R4iVe8p0uk6U61+gUtm3Z5V26o9whJe3eXeUMsNYEBQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -2077,110 +1560,14 @@
         "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/web-8-5/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-8-5/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.19.tgz",
-      "integrity": "sha512-JINggPK1nmR3IUSMEgpwst9/m23xCisM/ZDI3aFWuZzWQa0IFGAabvG+S0bWBg0uGeeaeFUsFzNlQVC6bY3xOw==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.20.tgz",
+      "integrity": "sha512-/S3O+QdJ4b88+HMzim1B+drxrYf4NCpAyU+6hbzhN2fL/yiqsGvXVWWGUeegU1dWGicvXA50vlgsfbh1lWMCMA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.1.19",
-        "@php-wasm/universal": "3.1.19",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-service-worker/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web-service-worker/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/web/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
+        "@php-wasm/scopes": "3.1.20",
+        "@php-wasm/universal": "3.1.20",
         "ini": "4.1.2"
       },
       "engines": {
@@ -2226,45 +1613,13 @@
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.19.tgz",
-      "integrity": "sha512-zv/wZZ1aFA1WHA6qJ6CbLiR6SRSwzRzn0c2v0r2l3cxmcbzWDR1tV1WVYyvuHhsgGZ8StVSbCccn1HqXJDcW1w==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.20.tgz",
+      "integrity": "sha512-F9RAsltz67xzDL9HcJHsVt89w4sUe1ccCioxjEBSkHrDcxb5vw2oSRuFteFkMFZwl1WdXy0c/AtC+xbf0M6C3A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@wp-playground/common/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@wp-playground/common/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
+        "@php-wasm/universal": "3.1.20",
+        "@php-wasm/util": "3.1.20",
         "ini": "4.1.2"
       },
       "engines": {
@@ -2273,14 +1628,14 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.19.tgz",
-      "integrity": "sha512-RRhqeUzs/DqaW4ZD7dEbdDOhnt4k6oG3CA2zNj36miHI40hyQP8YxbV492+np/tQWkJNGKMSRXWnt2LRC2NwpQ==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.20.tgz",
+      "integrity": "sha512-fchpDqFMOgJAkxTcTbiCDHaigo7DU+s3QInoBmwfYYxJtGzBxCYTjPkEnG2HEJXwLjDpHu2mnFF6ZZm1Cg3BuQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/universal": "3.1.19",
-        "@php-wasm/util": "3.1.19",
+        "@php-wasm/stream-compression": "3.1.20",
+        "@php-wasm/universal": "3.1.20",
+        "@php-wasm/util": "3.1.20",
         "@zip.js/zip.js": "2.7.57",
         "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
@@ -2295,38 +1650,6 @@
         "readable-stream": "^3.4.0",
         "sha.js": "^2.4.9",
         "simple-get": "^4.0.1"
-      }
-    },
-    "node_modules/@wp-playground/storage/node_modules/@php-wasm/progress": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.19.tgz",
-      "integrity": "sha512-GFQoHhWpImwDP+kiXC6iX5aeDUCpLG3aJD5/x40gbSAW1fsftfcowCzxQvM47X/gN+i02dS+0cvaR9PZqT6dFw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@wp-playground/storage/node_modules/@php-wasm/universal": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.19.tgz",
-      "integrity": "sha512-cmKc1nJZ3qehQopkxWWwhlL29ZXdX+PdaqLBaRwUz9xTS2cxQri+zcHrAWDjhC8WlAkzihCVui7laZI4bJkD4Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.19",
-        "@php-wasm/node-polyfills": "3.1.19",
-        "@php-wasm/progress": "3.1.19",
-        "@php-wasm/stream-compression": "3.1.19",
-        "@php-wasm/util": "3.1.19",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
       }
     },
     "node_modules/@wp-playground/storage/node_modules/diff3": {
@@ -2890,9 +2213,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -2905,9 +2228,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -2916,8 +2239,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -3102,9 +2425,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4094,9 +3417,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -10,11 +10,15 @@
   },
   "dependencies": {
     "@php-wasm/universal": "^3.1.20",
-    "@php-wasm/web": "^3.1.19",
+    "@php-wasm/web": "^3.1.20",
     "fflate": "^0.8.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
     "esbuild": "^0.28.0"
+  },
+  "overrides": {
+    "@php-wasm/universal": "$@php-wasm/universal",
+    "@php-wasm/web": "$@php-wasm/web"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the `Error: Runtime with id 1 not found` thrown at `popLoadedRuntime` on first boot of the playground (stack trace traced through `PHP.initializeRuntime` → `new PHP(runtimeId)` → `createPhpRuntime.refresh` in `src/runtime/php-loader.js`).

### Root cause

Dependabot bumped `@php-wasm/universal` to `3.1.20` (#41) but left `@php-wasm/web` at `3.1.19` (#40). Each published `@php-wasm/*` sub-package pins its siblings to exact versions, so `@php-wasm/web@3.1.19` declared `"@php-wasm/universal": "3.1.19"` and npm could not dedupe it against the top-level `@php-wasm/universal@3.1.20`.

As a result, esbuild bundled multiple copies of `load-php-runtime.js` into `dist/php-worker.bundle.js`, each with its own module-scoped `loadedRuntimes` `Map` and `lastRuntimeId` counter. `loadWebRuntime` (from `@php-wasm/web`) registered the new runtime in one `Map`, while `new PHP(runtimeId)` (from the top-level `@php-wasm/universal`) called `popLoadedRuntime` against a different `Map`, so the id was reported as missing.

You can see the duplication in the previously-built bundle: `loadedRuntimes`, `loadedRuntimes2`, `loadedRuntimes3`, `loadedRuntimes4`, each with a matching `popLoadedRuntime*`.

### Fix

- Bump `@php-wasm/web` to `^3.1.20` so its pinned sub-deps match the top-level `@php-wasm/universal`.
- Add npm `overrides` that force `@php-wasm/universal` and `@php-wasm/web` to the direct-dependency version across the whole tree. This keeps the two packages deduped even if a future Dependabot PR bumps one before the other.

After the fix, `npm ls @php-wasm/universal` shows a single `3.1.20` with every other occurrence `deduped`, and the rebuilt bundle contains exactly one `loadedRuntimes` / `popLoadedRuntime` definition.

## Test plan

- [x] `npm install` — lockfile regenerates cleanly, 0 vulnerabilities.
- [x] `npm ls @php-wasm/universal` — only one copy of `@php-wasm/universal@3.1.20`, everything else `deduped`.
- [x] `npm run sync-browser-deps && npm run build-worker` — bundle builds successfully.
- [x] `grep "var loadedRuntimes" dist/php-worker.bundle.js` — exactly one match (was 4+ before the fix).
- [x] `make lint` — passes (pre-existing Biome schema-version info only).
- [x] `make test` — 53/53 tests pass.
- [ ] Manual smoke test in a browser on GitHub Pages once deployed: verify the playground boots without the `Runtime with id 1 not found` error.