### PR TITLE
Support multiple Omeka S versions (4.1.1 + 4.2.0) with version dropdown

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Prepare runtime assets
         run: make prepare
 
-      - name: Build Omeka bundle
-        run: make bundle
+      - name: Build Omeka bundles (all supported versions)
+        run: make bundle-all
 
       - name: Install docs dependencies
         run: python -m pip install -r requirements-docs.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,13 +72,24 @@ make reset
 - `npm run sync-browser-deps`: vendors browser runtime dependencies (fflate)
 - `npm run prepare-runtime`: prepares the PHP runtime assets
 - `npm run build-worker`: bundles php-worker.js via esbuild into `dist/php-worker.bundle.js`
-- `npm run bundle`: fetches/builds Omeka and generates the readonly bundle
+- `npm run bundle`: fetches/builds Omeka for a single version (selected via the `OMEKA_VERSION` env var) and generates the readonly bundle + per-version manifest
+- `make bundle-all`: builds bundles for every supported Omeka version
 - `make serve`: runs the local Node dev server, including the addon proxy endpoint for remote blueprint ZIP downloads
+
+### Supported Omeka versions
+
+Supported versions are declared in `src/shared/omeka-versions.js` and consumed by:
+
+- the build scripts (to select the git branch or release ZIP to fetch)
+- the browser runtime (to pick the correct manifest URL at boot)
+- the shell UI (to render the version dropdown in Settings)
+
+Add a new version by appending an entry to `OMEKA_VERSIONS` (with a `source.type` of either `git` or `release-zip`) and adding a matching target in the `Makefile`.
 
 ### Generated Assets
 
-- `assets/omeka/`: readonly runtime bundle files (`.zip`)
-- `assets/manifests/`: generated bundle manifests
+- `assets/omeka/<version>/`: readonly runtime bundle files (`.zip`), one directory per supported Omeka version (e.g. `4.1.1`, `4.2.0`).
+- `assets/manifests/<version>.json`: generated bundle manifest per Omeka version. `latest.json` is written for the default version as a backward-compat alias.
 - `dist/`: esbuild-bundled worker and `@php-wasm` WASM binaries
 
 Do not hand-edit generated bundle artifacts unless the task is specifically about the build output.

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,46 @@
 PORT ?= 8080
-OMEKA_REF ?= https://github.com/ateeducacion/omeka-s.git
-OMEKA_REF_BRANCH ?= feature/experimental-sqlite-support
+OMEKA_VERSION ?=
+OMEKA_REF ?=
+OMEKA_REF_BRANCH ?=
 
 # Basic usage:
-#   make help      Show the available targets and common overrides
-#   make up        Install deps, prepare runtime assets, build Omeka, and start the dev server
-#   make serve     Start only the local dev server
-#   make bundle    Rebuild the readonly Omeka bundle
+#   make help             Show the available targets and common overrides
+#   make up               Install deps, prepare runtime assets, build all
+#                         Omeka versions, and start the dev server
+#   make serve            Start only the local dev server
+#   make bundle           Rebuild the readonly Omeka bundle for the default
+#                         version (override with OMEKA_VERSION=...)
+#   make bundle-all       Rebuild bundles for every supported Omeka version
 #
 # Common overrides:
 #   make serve PORT=9090
-#   make bundle OMEKA_REF=https://github.com/<org>/omeka-s.git OMEKA_REF_BRANCH=<branch>
+#   make bundle OMEKA_VERSION=4.1.1
+#   make bundle OMEKA_VERSION=4.2.0 OMEKA_REF=https://github.com/<org>/omeka-s.git OMEKA_REF_BRANCH=<branch>
 
-.PHONY: help up deps prepare bundle serve clean reset test lint format
+.PHONY: help up deps prepare bundle bundle-all bundle-4.1.1 bundle-4.2.0 serve clean reset test lint format
 
 help:
 	@printf '%s\n' \
 		'Omeka S Playground Make targets:' \
 		'' \
-		'  make deps      Install npm dependencies' \
-		'  make prepare   Sync browser deps and prepare runtime assets' \
-		'  make bundle    Build the readonly Omeka bundle' \
-		'  make serve     Start the local dev server' \
-		'  make up        Run bundle + serve' \
-		'  make test      Run tests' \
-		'  make lint      Check code with Biome' \
-		'  make format    Auto-fix code with Biome' \
-		'  make clean     Remove generated caches and bundle artifacts' \
-		'  make reset     Alias of clean plus cache reset' \
+		'  make deps          Install npm dependencies' \
+		'  make prepare       Sync browser deps and prepare runtime assets' \
+		'  make bundle        Build the readonly Omeka bundle for the default version' \
+		'  make bundle-all    Build bundles for every supported Omeka version' \
+		'  make bundle-4.1.1  Build only the Omeka 4.1.1 bundle' \
+		'  make bundle-4.2.0  Build only the Omeka 4.2.0 bundle' \
+		'  make serve         Start the local dev server' \
+		'  make up            Run bundle-all + serve' \
+		'  make test          Run tests' \
+		'  make lint          Check code with Biome' \
+		'  make format        Auto-fix code with Biome' \
+		'  make clean         Remove generated caches and bundle artifacts' \
+		'  make reset         Alias of clean plus cache reset' \
 		'' \
 		'Common overrides:' \
 		'  PORT=9090 make serve' \
-		'  OMEKA_REF=<repo> OMEKA_REF_BRANCH=<branch> make bundle'
+		'  OMEKA_VERSION=4.1.1 make bundle' \
+		'  OMEKA_REF=<repo> OMEKA_REF_BRANCH=<branch> make bundle OMEKA_VERSION=4.2.0'
 
 deps:
 	npm install
@@ -42,12 +51,22 @@ prepare: deps
 	npm run build-worker
 
 bundle: prepare
-	OMEKA_REF=$(OMEKA_REF) OMEKA_REF_BRANCH=$(OMEKA_REF_BRANCH) npm run bundle
+	OMEKA_VERSION=$(OMEKA_VERSION) OMEKA_REF=$(OMEKA_REF) OMEKA_REF_BRANCH=$(OMEKA_REF_BRANCH) npm run bundle
+
+bundle-all: prepare bundle-4.1.1 bundle-4.2.0
+
+# Per-version targets so recursive make can parallelise independent builds
+# (they share only the worker bundle and the vendor cache).
+bundle-4.1.1:
+	OMEKA_VERSION=4.1.1 npm run bundle
+
+bundle-4.2.0:
+	OMEKA_VERSION=4.2.0 OMEKA_REF=$(OMEKA_REF) OMEKA_REF_BRANCH=$(OMEKA_REF_BRANCH) npm run bundle
 
 serve:
 	PORT=$(PORT) node ./scripts/dev-server.mjs
 
-up: bundle serve
+up: bundle-all serve
 
 clean:
 	rm -rf .cache

--- a/index.html
+++ b/index.html
@@ -174,6 +174,11 @@
       <h2 class="settings-popover__title">Playground Settings</h2>
 
       <label class="settings-popover__field">
+        <span>Omeka S Version</span>
+        <select id="settings-omeka-version"></select>
+      </label>
+
+      <label class="settings-popover__field">
         <span>PHP Version</span>
         <select id="settings-php-version"></select>
       </label>

--- a/lib/omeka-loader.js
+++ b/lib/omeka-loader.js
@@ -1,9 +1,13 @@
-import { unzipSync } from "../vendor/fflate/esm/browser.js";
+import {
+  buildManifestFilename,
+  DEFAULT_OMEKA_VERSION,
+} from "../src/shared/omeka-versions.js";
 import { resolveProjectUrl } from "../src/shared/paths.js";
+import { unzipSync } from "../vendor/fflate/esm/browser.js";
 
 const CACHE_NAME = "omeka-playground-bundles";
 const DEFAULT_MANIFEST_URL = resolveProjectUrl(
-  "assets/manifests/latest.json",
+  `assets/manifests/${buildManifestFilename(DEFAULT_OMEKA_VERSION)}`,
 ).toString();
 
 /**

--- a/php-worker.js
+++ b/php-worker.js
@@ -1,5 +1,11 @@
 import { loadPlaygroundConfig } from "./src/shared/config.js";
 import {
+  DEFAULT_OMEKA_VERSION,
+  parseRuntimeId,
+  resolveRuntimeConfig,
+  resolveVersions,
+} from "./src/shared/omeka-versions.js";
+import {
   createPhpBridgeChannel,
   createShellChannel,
 } from "./src/shared/protocol.js";
@@ -115,9 +121,21 @@ async function getRuntimeState() {
 
   runtimeStatePromise = (async () => {
     const config = await loadPlaygroundConfig();
-    const runtime =
-      config.runtimes.find((entry) => entry.id === runtimeId) ||
-      config.runtimes[0];
+    const parsedRuntime = parseRuntimeId(runtimeId);
+    const resolvedSelection = resolveVersions({
+      runtimeId,
+      phpVersion: parsedRuntime?.phpVersion,
+      omekaVersion: parsedRuntime?.omekaVersion,
+    });
+    const runtime = resolveRuntimeConfig(config, {
+      runtimeId,
+      phpVersion: resolvedSelection.phpVersion,
+      omekaVersion: resolvedSelection.omekaVersion,
+    });
+    const omekaVersion =
+      runtime?.omekaVersion ||
+      resolvedSelection.omekaVersion ||
+      DEFAULT_OMEKA_VERSION;
     const appBaseUrl =
       typeof __APP_ROOT__ !== "undefined"
         ? __APP_ROOT__
@@ -136,7 +154,10 @@ async function getRuntimeState() {
       });
     const php = createPhpRuntime(runtime, {
       appBaseUrl,
-      phpVersion: runtime.phpVersion || runtime.phpVersionLabel,
+      phpVersion:
+        runtime.phpVersion ||
+        runtime.phpVersionLabel ||
+        resolvedSelection.phpVersion,
       phpCorsProxyUrl: config.phpCorsProxyUrl || null,
       cliExecutor,
     });
@@ -177,6 +198,7 @@ async function getRuntimeState() {
         config,
         blueprint: activeBlueprint,
         clean: forceCleanBoot,
+        omekaVersion,
         php,
         publish,
         runtimeId,

--- a/playground.config.json
+++ b/playground.config.json
@@ -15,36 +15,23 @@
     "password": "password",
     "email": "admin@example.com"
   },
-  "omekaVersion": "4.2.0",
+  "defaults": {
+    "phpVersion": "8.3",
+    "omekaVersion": "4.2.0"
+  },
   "runtimes": [
     {
-      "id": "php81",
-      "label": "PHP 8.1",
-      "phpVersion": "8.1",
-      "default": false
-    },
-    {
-      "id": "php82",
-      "label": "PHP 8.2",
-      "phpVersion": "8.2",
-      "default": false
-    },
-    {
-      "id": "php83",
-      "label": "PHP 8.3",
+      "id": "php83-omeka420",
+      "label": "PHP 8.3 + Omeka S 4.2.0",
       "phpVersion": "8.3",
+      "omekaVersion": "4.2.0",
       "default": true
     },
     {
-      "id": "php84",
-      "label": "PHP 8.4",
-      "phpVersion": "8.4",
-      "default": false
-    },
-    {
-      "id": "php85",
-      "label": "PHP 8.5",
-      "phpVersion": "8.5",
+      "id": "php83-omeka411",
+      "label": "PHP 8.3 + Omeka S 4.1.1",
+      "phpVersion": "8.3",
+      "omekaVersion": "4.1.1",
       "default": false
     }
   ]

--- a/scripts/build-omeka-bundle.sh
+++ b/scripts/build-omeka-bundle.sh
@@ -1,14 +1,97 @@
 #!/bin/sh
 
+# Build a readonly Omeka S bundle and manifest for a specific Omeka version.
+#
+# Usage:
+#   OMEKA_VERSION=4.2.0 scripts/build-omeka-bundle.sh
+#   OMEKA_VERSION=4.1.1 scripts/build-omeka-bundle.sh
+#
+# Environment:
+#   OMEKA_VERSION     Required. Must match a version in
+#                     src/shared/omeka-versions.js (default: the declared
+#                     default version).
+#   OMEKA_REF         Override the git remote URL (only used for source
+#                     type "git" — backward compat with the old single
+#                     version build).
+#   OMEKA_REF_BRANCH  Override the git branch (same as above).
+
 set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 WORK_DIR=${WORK_DIR:-"$REPO_DIR/.cache/build-omeka"}
-DIST_DIR=${DIST_DIR:-"$REPO_DIR/assets/omeka"}
+DIST_ROOT=${DIST_ROOT:-"$REPO_DIR/assets/omeka"}
 MANIFEST_DIR=${MANIFEST_DIR:-"$REPO_DIR/assets/manifests"}
-SOURCE_DIR=$("$SCRIPT_DIR/fetch-omeka-source.sh")
-STAGE_DIR="$WORK_DIR/stage"
+
+# Resolve the requested version against the shared version resolver so the
+# build script, the browser runtime, and the shell UI all share a single
+# source of truth for supported versions.
+VERSION_REQUEST=${OMEKA_VERSION:-}
+META_JSON=$(node --input-type=module -e "
+  import('${REPO_DIR}/src/shared/omeka-versions.js').then((m) => {
+    const requested = process.env.VERSION_REQUEST || '';
+    const resolved = requested ? m.resolveOmekaVersion(requested) : m.DEFAULT_OMEKA_VERSION;
+    if (!resolved) {
+      console.error(\`Unsupported OMEKA_VERSION: \${requested}\`);
+      process.exit(2);
+    }
+    const meta = m.getOmekaVersionMetadata(resolved);
+    process.stdout.write(JSON.stringify(meta));
+  }).catch((err) => {
+    console.error(err?.stack || String(err));
+    process.exit(1);
+  });
+" VERSION_REQUEST="${VERSION_REQUEST}")
+
+get_meta() {
+  printf '%s' "$META_JSON" | node -e "
+    let data = '';
+    process.stdin.on('data', (c) => { data += c; });
+    process.stdin.on('end', () => {
+      const meta = JSON.parse(data);
+      const key = process.argv[1];
+      const value = key.split('.').reduce((o, k) => (o == null ? o : o[k]), meta);
+      process.stdout.write(value == null ? '' : String(value));
+    });
+  " "$1"
+}
+
+VERSION=$(get_meta version)
+SOURCE_TYPE=$(get_meta source.type)
+MANIFEST_FILE=$(get_meta manifestFile)
+BUNDLE_DIR_NAME=$(get_meta bundleDir)
+
+if [ -z "$VERSION" ] || [ -z "$SOURCE_TYPE" ] || [ -z "$MANIFEST_FILE" ] || [ -z "$BUNDLE_DIR_NAME" ]; then
+  echo "build-omeka-bundle: unable to resolve metadata for version '${VERSION_REQUEST:-<default>}'." >&2
+  exit 2
+fi
+
+DIST_DIR="$DIST_ROOT/$BUNDLE_DIR_NAME"
+MANIFEST_PATH="$MANIFEST_DIR/$MANIFEST_FILE"
+
+case "$SOURCE_TYPE" in
+  git)
+    SOURCE_REPO=${OMEKA_REF:-$(get_meta source.repository)}
+    SOURCE_BRANCH=${OMEKA_REF_BRANCH:-$(get_meta source.branch)}
+    SOURCE_DIR=$("$SCRIPT_DIR/fetch-omeka-source.sh" "$SOURCE_REPO" "$SOURCE_BRANCH" "$VERSION")
+    SOURCE_COMMIT=$(git -C "$SOURCE_DIR" rev-parse HEAD)
+    SOURCE_URL="$SOURCE_REPO"
+    SOURCE_REF="$SOURCE_BRANCH"
+    ;;
+  release-zip)
+    RELEASE_URL=$(get_meta source.url)
+    SOURCE_DIR=$("$SCRIPT_DIR/fetch-omeka-release.sh" "$VERSION" "$RELEASE_URL")
+    SOURCE_COMMIT=""
+    SOURCE_URL="$RELEASE_URL"
+    SOURCE_REF="v$VERSION"
+    ;;
+  *)
+    echo "build-omeka-bundle: unsupported source type '$SOURCE_TYPE'." >&2
+    exit 2
+    ;;
+esac
+
+STAGE_DIR="$WORK_DIR/$BUNDLE_DIR_NAME/stage"
 OMEKA_STAGE="$STAGE_DIR/omeka"
 
 rm -rf "$STAGE_DIR"
@@ -31,35 +114,52 @@ perl -0pi -e "s/\\n\\\$this->headLink\\(\\)->prependStylesheet\\('\\/\\/fonts\\.
   "$OMEKA_STAGE/application/view/layout/layout.phtml" \
   "$OMEKA_STAGE/application/view/common/user-bar.phtml"
 
-if command -v composer >/dev/null 2>&1; then
-  composer install --working-dir="$OMEKA_STAGE" --no-dev --prefer-dist --no-progress --no-interaction --ignore-platform-reqs >&2
-else
-  echo "composer is required to materialize Omeka vendor dependencies for the browser bundle." >&2
-  exit 1
+if [ ! -d "$OMEKA_STAGE/vendor" ]; then
+  if command -v composer >/dev/null 2>&1; then
+    composer install --working-dir="$OMEKA_STAGE" --no-dev --prefer-dist --no-progress --no-interaction --ignore-platform-reqs >&2
+  else
+    echo "composer is required to materialize Omeka vendor dependencies for the browser bundle." >&2
+    exit 1
+  fi
 fi
 
-SOURCE_COMMIT=$(git -C "$SOURCE_DIR" rev-parse HEAD)
 RELEASE=$(php -r 'preg_match("/const VERSION = \x27([^\x27]+)\x27;/", file_get_contents("'"$OMEKA_STAGE"'/application/Module.php"), $m); echo $m[1] ?? "unknown";')
+if [ -z "$RELEASE" ] || [ "$RELEASE" = "unknown" ]; then
+  RELEASE="$VERSION"
+fi
 SAFE_RELEASE=$(printf '%s' "$RELEASE" | sed 's/[^A-Za-z0-9._-]/_/g')
 BUNDLE_FILE="omeka-core-${SAFE_RELEASE}.zip"
 BUNDLE_PATH="$DIST_DIR/$BUNDLE_FILE"
-MANIFEST_PATH="$MANIFEST_DIR/latest.json"
 FILE_COUNT=$(find "$OMEKA_STAGE" -type f | wc -l | tr -d ' ')
 
-# Create ZIP bundle
-echo "Creating ZIP bundle..." >&2
+# Drop any stale bundle(s) in this version's dist dir so the manifest path
+# always points at the freshly built artifact.
+find "$DIST_DIR" -maxdepth 1 -type f -name 'omeka-core-*.zip' ! -name "$BUNDLE_FILE" -delete 2>/dev/null || true
+
+echo "Creating ZIP bundle for Omeka $RELEASE..." >&2
 (cd "$OMEKA_STAGE" && zip -qr "$BUNDLE_PATH" .)
 echo "Bundle created: $BUNDLE_PATH ($FILE_COUNT files)" >&2
 
-node "$SCRIPT_DIR/generate-manifest.mjs" \
-  --channel browser \
-  --manifest "$MANIFEST_PATH" \
-  --release "$RELEASE" \
-  --sourceRepository "${OMEKA_REF:-https://github.com/ateeducacion/omeka-s.git}" \
-  --sourceBranch "${OMEKA_REF_BRANCH:-feature/experimental-sqlite-support}" \
-  --sourceCommit "$SOURCE_COMMIT" \
-  --bundle "$BUNDLE_PATH" \
-  --fileCount "$FILE_COUNT"
+MANIFEST_ARGS="--channel browser --manifest $MANIFEST_PATH --release $RELEASE --sourceRepository $SOURCE_URL --sourceBranch $SOURCE_REF --bundle $BUNDLE_PATH --fileCount $FILE_COUNT"
+if [ -n "$SOURCE_COMMIT" ]; then
+  MANIFEST_ARGS="$MANIFEST_ARGS --sourceCommit $SOURCE_COMMIT"
+fi
+
+# Intentionally unquoted so shell word-splitting produces separate argv entries.
+# shellcheck disable=SC2086
+node "$SCRIPT_DIR/generate-manifest.mjs" $MANIFEST_ARGS
+
+# Keep the legacy manifest URL pointing at whichever version is default so
+# callers that haven't migrated to version-specific URLs still work.
+DEFAULT_VERSION=$(node --input-type=module -e "
+  import('${REPO_DIR}/src/shared/omeka-versions.js').then((m) => {
+    process.stdout.write(m.DEFAULT_OMEKA_VERSION);
+  });
+")
+if [ "$VERSION" = "$DEFAULT_VERSION" ]; then
+  cp "$MANIFEST_PATH" "$MANIFEST_DIR/latest.json"
+  echo "Also wrote $MANIFEST_DIR/latest.json (default version alias)" >&2
+fi
 
 echo "Bundle written to $BUNDLE_PATH" >&2
 echo "Manifest written to $MANIFEST_PATH" >&2

--- a/scripts/fetch-omeka-release.sh
+++ b/scripts/fetch-omeka-release.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# Fetch an Omeka S release ZIP from GitHub and extract it into a cache
+# directory. Prints the absolute path of the extracted source tree on
+# stdout so the caller can pipe it to the bundle builder.
+#
+# Usage:
+#   fetch-omeka-release.sh <version> <release-url>
+#
+# Environment:
+#   CACHE_DIR   Override the cache root (default: <repo>/.cache/omeka-release)
+
+set -eu
+
+VERSION=${1:?"fetch-omeka-release.sh: version argument is required"}
+URL=${2:?"fetch-omeka-release.sh: release URL argument is required"}
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+CACHE_DIR=${CACHE_DIR:-"$REPO_DIR/.cache/omeka-release"}
+VERSION_DIR="$CACHE_DIR/$VERSION"
+ARCHIVE_PATH="$VERSION_DIR/omeka-s-$VERSION.zip"
+EXTRACT_DIR="$VERSION_DIR/source"
+
+mkdir -p "$VERSION_DIR"
+
+if [ ! -f "$ARCHIVE_PATH" ]; then
+  echo "Downloading $URL" >&2
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL --retry 3 --retry-delay 2 -o "$ARCHIVE_PATH.part" "$URL"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$ARCHIVE_PATH.part" "$URL"
+  else
+    echo "curl or wget is required to download the Omeka release." >&2
+    exit 1
+  fi
+  mv "$ARCHIVE_PATH.part" "$ARCHIVE_PATH"
+fi
+
+if [ ! -d "$EXTRACT_DIR" ]; then
+  rm -rf "$EXTRACT_DIR"
+  mkdir -p "$EXTRACT_DIR"
+  echo "Extracting $ARCHIVE_PATH" >&2
+  unzip -q "$ARCHIVE_PATH" -d "$EXTRACT_DIR"
+fi
+
+# Release archives contain a single top-level directory (e.g. "omeka-s").
+# Resolve to that inner directory so downstream callers see the source
+# tree directly.
+INNER=$(find "$EXTRACT_DIR" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+if [ -z "$INNER" ]; then
+  echo "Unable to locate extracted Omeka directory inside $EXTRACT_DIR" >&2
+  exit 1
+fi
+
+printf '%s\n' "$INNER"

--- a/scripts/fetch-omeka-source.sh
+++ b/scripts/fetch-omeka-source.sh
@@ -1,17 +1,39 @@
 #!/bin/sh
 
+# Fetch an Omeka S source tree from a git remote into a cache directory.
+# Prints the absolute path of the cloned repository on stdout.
+#
+# Arguments (all optional for backward compat — fall back to env vars):
+#   $1  remote URL (also OMEKA_REF)
+#   $2  ref/branch name (also OMEKA_REF_BRANCH)
+#   $3  version label used to pick a per-version cache path
+#
+# Environment:
+#   CACHE_DIR          Override cache root (default: <repo>/.cache/omeka-source)
+#   OMEKA_REF          Remote URL when $1 is unset
+#   OMEKA_REF_BRANCH   Ref when $2 is unset
+
 set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 CACHE_DIR=${CACHE_DIR:-"$REPO_DIR/.cache/omeka-source"}
-REF_URL=${OMEKA_REF:-"https://github.com/ateeducacion/omeka-s.git"}
-REF_BRANCH=${OMEKA_REF_BRANCH:-"feature/experimental-sqlite-support"}
-CLONE_DIR="$CACHE_DIR/repository"
 
-mkdir -p "$CACHE_DIR"
+REF_URL=${1:-${OMEKA_REF:-"https://github.com/ateeducacion/omeka-s.git"}}
+REF_BRANCH=${2:-${OMEKA_REF_BRANCH:-"feature/experimental-sqlite-support"}}
+LABEL=${3:-default}
+
+# Use a per-version clone directory so building multiple versions side by
+# side doesn't thrash a shared working tree.
+SAFE_LABEL=$(printf '%s' "$LABEL" | sed 's/[^A-Za-z0-9._-]/_/g')
+CLONE_DIR="$CACHE_DIR/$SAFE_LABEL/repository"
+
+mkdir -p "$CLONE_DIR"
 
 if [ ! -d "$CLONE_DIR/.git" ]; then
+  # Clone may have been partially created above; `git clone` refuses to
+  # clone into a non-empty directory, so remove it first.
+  rm -rf "$CLONE_DIR"
   git clone --depth 1 --branch "$REF_BRANCH" "$REF_URL" "$CLONE_DIR" >&2
 else
   git -C "$CLONE_DIR" fetch --depth 1 origin "$REF_BRANCH" >&2
@@ -20,4 +42,3 @@ else
 fi
 
 printf '%s\n' "$CLONE_DIR"
-

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -31,16 +31,20 @@ const manifestPath = resolve(args.manifest);
 const bundlePath = resolve(args.bundle);
 const bundleStat = statSync(bundlePath);
 
+const source = {
+  repository: args.sourceRepository,
+  branch: args.sourceBranch,
+};
+if (args.sourceCommit) {
+  source.commit = args.sourceCommit;
+}
+
 const manifest = {
   schemaVersion: 2,
   generatedAt: new Date().toISOString(),
   channel: args.channel,
   release: args.release,
-  source: {
-    repository: args.sourceRepository,
-    branch: args.sourceBranch,
-    commit: args.sourceCommit,
-  },
+  source,
   bundle: {
     format: "zip",
     path: relative(resolve(manifestPath, ".."), bundlePath).replaceAll(

--- a/src/remote/main.js
+++ b/src/remote/main.js
@@ -1,5 +1,6 @@
 import { loadActiveBlueprint } from "../shared/blueprint.js";
-import { getDefaultRuntime, loadPlaygroundConfig } from "../shared/config.js";
+import { loadPlaygroundConfig } from "../shared/config.js";
+import { resolveRuntimeConfig } from "../shared/omeka-versions.js";
 import { buildScopedSitePath } from "../shared/paths.js";
 import { createShellChannel } from "../shared/protocol.js";
 import { saveSessionState } from "../shared/storage.js";
@@ -217,9 +218,9 @@ async function bootstrapRemote() {
   activePath = requestedPath;
   const config = await loadPlaygroundConfig();
   const blueprint = loadActiveBlueprint(scopeId);
-  const runtime =
-    config.runtimes.find((entry) => entry.id === requestedRuntimeId) ||
-    getDefaultRuntime(config);
+  const runtime = resolveRuntimeConfig(config, {
+    runtimeId: requestedRuntimeId,
+  });
   setOverlayVisible(true);
 
   setRemoteProgress(

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -1199,6 +1199,7 @@ async function appendPhpIniOverrides(php, config) {
 export async function prepareOmekaRuntimeFilesystem({
   blueprint,
   config,
+  omekaVersion,
   php,
   publish = () => {},
   runtimeId,
@@ -1214,7 +1215,7 @@ export async function prepareOmekaRuntimeFilesystem({
   await ensureMutableLayout(php);
 
   publish("Loading Omeka readonly bundle manifest.", 0.28);
-  const manifest = await fetchManifest();
+  const manifest = await fetchManifest({ omekaVersion });
   const manifestState = buildManifestState(
     manifest,
     runtimeId,
@@ -1253,6 +1254,7 @@ export async function bootstrapOmeka({
   blueprint,
   clean = false,
   config,
+  omekaVersion,
   php,
   publish,
   runtimeId,
@@ -1266,6 +1268,7 @@ export async function bootstrapOmeka({
     await prepareOmekaRuntimeFilesystem({
       blueprint,
       config,
+      omekaVersion,
       php,
       publish,
       runtimeId,

--- a/src/runtime/manifest.js
+++ b/src/runtime/manifest.js
@@ -1,14 +1,38 @@
+import {
+  buildManifestFilename,
+  DEFAULT_OMEKA_VERSION,
+} from "../shared/omeka-versions.js";
 import { resolveProjectUrl } from "../shared/paths.js";
 
-export async function fetchManifest() {
-  const url = resolveProjectUrl("assets/manifests/latest.json");
-  const response = await fetch(url, { cache: "no-cache" });
-  if (!response.ok) {
+export function buildManifestUrl(omekaVersion) {
+  const filename = buildManifestFilename(omekaVersion || DEFAULT_OMEKA_VERSION);
+  return resolveProjectUrl(`assets/manifests/${filename}`);
+}
+
+export async function fetchManifest({ omekaVersion } = {}) {
+  const versioned = buildManifestUrl(omekaVersion);
+  const response = await fetch(versioned, { cache: "no-cache" });
+  if (response.ok) {
+    const manifest = await response.json();
+    manifest._manifestUrl = versioned.toString();
+    return manifest;
+  }
+
+  if (response.status !== 404) {
     throw new Error(`Unable to load Omeka manifest: ${response.status}`);
   }
-  const manifest = await response.json();
-  // Attach the manifest URL so vfs.js can resolve relative bundle paths.
-  manifest._manifestUrl = url.toString();
+
+  // Fall back to the legacy default manifest for installs that haven't
+  // regenerated per-version assets yet.
+  const fallback = resolveProjectUrl("assets/manifests/latest.json");
+  const fallbackResponse = await fetch(fallback, { cache: "no-cache" });
+  if (!fallbackResponse.ok) {
+    throw new Error(
+      `Unable to load Omeka manifest (version=${omekaVersion || "default"}): ${response.status}`,
+    );
+  }
+  const manifest = await fallbackResponse.json();
+  manifest._manifestUrl = fallback.toString();
   return manifest;
 }
 

--- a/src/shared/blueprint.js
+++ b/src/shared/blueprint.js
@@ -1,3 +1,8 @@
+import {
+  DEFAULT_OMEKA_VERSION,
+  DEFAULT_PHP_VERSION,
+  resolveOmekaVersion,
+} from "./omeka-versions.js";
 import { resolveProjectUrl } from "./paths.js";
 import { SNAPSHOT_VERSION } from "./protocol.js";
 
@@ -207,10 +212,15 @@ export function buildDefaultBlueprint(config) {
     },
     preferredVersions: {
       php:
-        config.runtimes?.find((runtime) => runtime.default)?.phpVersionLabel ||
-        config.runtimes?.[0]?.phpVersionLabel ||
-        "8.3",
-      omeka: "4.2.0",
+        config.defaults?.phpVersion ||
+        config.runtimes?.find((runtime) => runtime.default)?.phpVersion ||
+        config.runtimes?.[0]?.phpVersion ||
+        DEFAULT_PHP_VERSION,
+      omeka:
+        config.defaults?.omekaVersion ||
+        config.runtimes?.find((runtime) => runtime.default)?.omekaVersion ||
+        config.runtimes?.[0]?.omekaVersion ||
+        DEFAULT_OMEKA_VERSION,
     },
     debug: {
       enabled: false,
@@ -339,7 +349,8 @@ export function normalizeBlueprint(input, config) {
     preferredVersions: {
       php: blueprint.preferredVersions?.php || fallback.preferredVersions.php,
       omeka:
-        blueprint.preferredVersions?.omeka || fallback.preferredVersions.omeka,
+        resolveOmekaVersion(blueprint.preferredVersions?.omeka) ||
+        fallback.preferredVersions.omeka,
     },
     debug: {
       enabled: blueprint.debug?.enabled === true,

--- a/src/shared/omeka-versions.js
+++ b/src/shared/omeka-versions.js
@@ -1,0 +1,325 @@
+/**
+ * Single source of truth for supported Omeka S versions, PHP versions,
+ * and compatibility matrix. Inspired by moodle-playground's
+ * src/shared/version-resolver.js.
+ *
+ * The `source` field describes how scripts/build-omeka-bundle.sh should
+ * fetch the source tree for each version. It is not consumed by the
+ * browser runtime.
+ */
+
+export const OMEKA_VERSIONS = [
+  {
+    version: "4.1.1",
+    label: "Omeka S 4.1.1",
+    slug: "4.1.1",
+    manifestFile: "4.1.1.json",
+    bundleDir: "4.1.1",
+    phpVersions: ["8.1", "8.2", "8.3", "8.4", "8.5"],
+    source: {
+      type: "release-zip",
+      url: "https://github.com/omeka/omeka-s/releases/download/v4.1.1/omeka-s-4.1.1.zip",
+    },
+    default: false,
+  },
+  {
+    version: "4.2.0",
+    label: "Omeka S 4.2.0 (experimental SQLite)",
+    slug: "4.2.0",
+    manifestFile: "4.2.0.json",
+    bundleDir: "4.2.0",
+    phpVersions: ["8.1", "8.2", "8.3", "8.4", "8.5"],
+    source: {
+      type: "git",
+      repository: "https://github.com/ateeducacion/omeka-s.git",
+      branch: "feature/experimental-sqlite-support",
+    },
+    default: true,
+  },
+];
+
+export const ALL_PHP_VERSIONS = ["8.1", "8.2", "8.3", "8.4", "8.5"];
+export const DEFAULT_PHP_VERSION = "8.3";
+export const DEFAULT_OMEKA_VERSION = (
+  OMEKA_VERSIONS.find((entry) => entry.default) || OMEKA_VERSIONS[0]
+).version;
+
+function normalizeStringParam(value) {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+/**
+ * Get the metadata object for a given Omeka version.
+ */
+export function getOmekaVersionMetadata(version) {
+  if (!version) {
+    return null;
+  }
+  const needle = String(version).trim();
+  return (
+    OMEKA_VERSIONS.find(
+      (entry) => entry.version === needle || entry.slug === needle,
+    ) || null
+  );
+}
+
+/**
+ * Get the default Omeka version metadata.
+ */
+export function getDefaultOmekaVersion() {
+  return OMEKA_VERSIONS.find((entry) => entry.default) || OMEKA_VERSIONS[0];
+}
+
+/**
+ * Return the list of PHP versions compatible with a given Omeka version.
+ */
+export function getCompatiblePhpVersions(version) {
+  const meta = getOmekaVersionMetadata(version);
+  return meta ? meta.phpVersions : [DEFAULT_PHP_VERSION];
+}
+
+/**
+ * Check whether a PHP version is compatible with an Omeka version.
+ */
+export function isCompatibleCombination(phpVersion, omekaVersion) {
+  const meta = getOmekaVersionMetadata(omekaVersion);
+  if (!meta) {
+    return false;
+  }
+  return meta.phpVersions.includes(phpVersion);
+}
+
+/**
+ * Resolve an Omeka version string (e.g. "4.1", "4.1.1", "4.2") to the
+ * canonical version string declared in OMEKA_VERSIONS. Returns null if
+ * no match is found.
+ */
+export function resolveOmekaVersion(input) {
+  const needle = normalizeStringParam(input);
+  if (!needle) {
+    return null;
+  }
+
+  const direct = getOmekaVersionMetadata(needle);
+  if (direct) {
+    return direct.version;
+  }
+
+  // Loose "major.minor" match — pick the first declared patch version for
+  // that minor line (e.g. "4.1" -> "4.1.1").
+  const minorMatch = needle.match(/^(\d+)\.(\d+)$/u);
+  if (minorMatch) {
+    const prefix = `${minorMatch[1]}.${minorMatch[2]}.`;
+    const byMinor = OMEKA_VERSIONS.find((entry) =>
+      entry.version.startsWith(prefix),
+    );
+    if (byMinor) {
+      return byMinor.version;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build a runtime ID encoding both PHP version and Omeka version.
+ * e.g., "php83-omeka420", "php83-omeka411".
+ */
+export function buildRuntimeId(phpVersion, omekaVersion) {
+  const phpPart = `php${String(phpVersion).replace(".", "")}`;
+  const meta = getOmekaVersionMetadata(omekaVersion);
+  const omekaPart = meta
+    ? `omeka${meta.version.replaceAll(".", "")}`
+    : `omeka${String(omekaVersion).replaceAll(/[^A-Za-z0-9]/gu, "")}`;
+  return `${phpPart}-${omekaPart}`;
+}
+
+/**
+ * Parse a runtime ID back to { phpVersion, omekaVersion }.
+ *
+ * Accepts the new "phpXY-omekaNNN" format and the legacy "phpXY" format
+ * (which maps to the default Omeka version).
+ */
+export function parseRuntimeId(runtimeId) {
+  if (!runtimeId || typeof runtimeId !== "string") {
+    return null;
+  }
+
+  const newMatch = runtimeId.match(/^php(\d)(\d)-omeka(\d+)$/u);
+  if (newMatch) {
+    const phpVersion = `${newMatch[1]}.${newMatch[2]}`;
+    const digits = newMatch[3];
+    const byExact = OMEKA_VERSIONS.find(
+      (entry) => entry.version.replaceAll(".", "") === digits,
+    );
+    if (byExact) {
+      return { phpVersion, omekaVersion: byExact.version };
+    }
+
+    // Tolerate shortened forms like "omeka41" -> try "4.1" loose match.
+    if (digits.length >= 2) {
+      const loose = resolveOmekaVersion(
+        `${digits[0]}.${digits.slice(1)}`.replace(
+          /^(\d+)\.(\d)(\d+)$/u,
+          "$1.$2.$3",
+        ),
+      );
+      if (loose) {
+        return { phpVersion, omekaVersion: loose };
+      }
+    }
+  }
+
+  const legacyMatch = runtimeId.match(/^php(\d)(\d)(?:-cgi)?$/u);
+  if (legacyMatch) {
+    return {
+      phpVersion: `${legacyMatch[1]}.${legacyMatch[2]}`,
+      omekaVersion: DEFAULT_OMEKA_VERSION,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve version selections from URL params, blueprint, runtime id, or
+ * defaults. Precedence: explicit params > blueprint > runtime id > default.
+ */
+export function resolveVersions({
+  php,
+  phpVersion,
+  omeka,
+  omekaVersion,
+  runtimeId,
+} = {}) {
+  const parsedRuntime = parseRuntimeId(runtimeId);
+
+  let resolvedOmeka = null;
+  if (omekaVersion) {
+    resolvedOmeka = resolveOmekaVersion(omekaVersion);
+  }
+  if (!resolvedOmeka && omeka) {
+    resolvedOmeka = resolveOmekaVersion(omeka);
+  }
+  if (!resolvedOmeka && parsedRuntime?.omekaVersion) {
+    resolvedOmeka = parsedRuntime.omekaVersion;
+  }
+  if (!resolvedOmeka) {
+    resolvedOmeka = DEFAULT_OMEKA_VERSION;
+  }
+
+  let resolvedPhp =
+    normalizeStringParam(phpVersion) || normalizeStringParam(php);
+  if (!resolvedPhp && parsedRuntime?.phpVersion) {
+    resolvedPhp = parsedRuntime.phpVersion;
+  }
+  if (resolvedPhp && !isCompatibleCombination(resolvedPhp, resolvedOmeka)) {
+    resolvedPhp = null;
+  }
+  if (!resolvedPhp) {
+    const compatible = getCompatiblePhpVersions(resolvedOmeka);
+    resolvedPhp = compatible.includes(DEFAULT_PHP_VERSION)
+      ? DEFAULT_PHP_VERSION
+      : compatible[0];
+  }
+
+  return { phpVersion: resolvedPhp, omekaVersion: resolvedOmeka };
+}
+
+export function resolveRuntimeSelection(options = {}) {
+  const resolved = resolveVersions(options);
+  return {
+    phpVersion: resolved.phpVersion,
+    omekaVersion: resolved.omekaVersion,
+    runtimeId: buildRuntimeId(resolved.phpVersion, resolved.omekaVersion),
+  };
+}
+
+export function buildRuntimeLabel(phpVersion, omekaVersion) {
+  const meta = getOmekaVersionMetadata(omekaVersion);
+  return `PHP ${phpVersion} + ${meta?.label || `Omeka S ${omekaVersion}`}`;
+}
+
+/**
+ * Resolve a runtime config entry for the given selection, synthesising a
+ * new entry if no exact match exists in playground.config.json. This lets
+ * the config keep only a curated list of runtimes while the UI can still
+ * offer every valid (php, omeka) combination.
+ */
+export function resolveRuntimeConfig(config, selection) {
+  const baseRuntime =
+    config?.runtimes?.find((runtime) => runtime.default) ||
+    config?.runtimes?.[0];
+  if (!baseRuntime) {
+    return null;
+  }
+
+  const runtimeId = selection?.runtimeId || baseRuntime.id;
+  const resolvedSelection =
+    selection?.phpVersion && selection?.omekaVersion
+      ? selection
+      : resolveRuntimeSelection({ runtimeId });
+
+  const exactRuntime = config.runtimes.find((entry) => entry.id === runtimeId);
+  if (exactRuntime) {
+    return exactRuntime;
+  }
+
+  const equivalentRuntime = config.runtimes.find((entry) => {
+    const parsed = parseRuntimeId(entry.id);
+    return (
+      parsed &&
+      parsed.phpVersion === resolvedSelection.phpVersion &&
+      parsed.omekaVersion === resolvedSelection.omekaVersion
+    );
+  });
+
+  return {
+    ...(equivalentRuntime || baseRuntime),
+    id: resolvedSelection.runtimeId,
+    label: buildRuntimeLabel(
+      resolvedSelection.phpVersion,
+      resolvedSelection.omekaVersion,
+    ),
+    phpVersion: resolvedSelection.phpVersion,
+    omekaVersion: resolvedSelection.omekaVersion,
+  };
+}
+
+/**
+ * Parse URL query params for version configuration.
+ */
+export function parseQueryParams(urlOrSearchParams) {
+  let params;
+  if (urlOrSearchParams instanceof URLSearchParams) {
+    params = urlOrSearchParams;
+  } else if (typeof urlOrSearchParams === "string") {
+    params = new URL(urlOrSearchParams).searchParams;
+  } else if (urlOrSearchParams?.searchParams) {
+    params = urlOrSearchParams.searchParams;
+  } else if (typeof urlOrSearchParams?.search === "string") {
+    params = new URLSearchParams(urlOrSearchParams.search);
+  } else {
+    params = new URLSearchParams();
+  }
+
+  return {
+    php: params.get("php") || params.get("phpVersion") || null,
+    phpVersion: params.get("phpVersion") || null,
+    omeka: params.get("omeka") || null,
+    omekaVersion: params.get("omekaVersion") || null,
+  };
+}
+
+/**
+ * Build the manifest URL for a given Omeka version.
+ */
+export function buildManifestFilename(omekaVersion) {
+  const meta = getOmekaVersionMetadata(omekaVersion);
+  return meta ? meta.manifestFile : "latest.json";
+}

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -5,7 +5,16 @@ import {
   parseImportedBlueprintPayload,
   resolveBlueprintForShell,
 } from "../shared/blueprint.js";
-import { getDefaultRuntime, loadPlaygroundConfig } from "../shared/config.js";
+import { loadPlaygroundConfig } from "../shared/config.js";
+import {
+  DEFAULT_OMEKA_VERSION,
+  DEFAULT_PHP_VERSION,
+  getCompatiblePhpVersions,
+  getOmekaVersionMetadata,
+  OMEKA_VERSIONS,
+  parseQueryParams,
+  resolveRuntimeSelection,
+} from "../shared/omeka-versions.js";
 import { hasBlueprintUrlOverride, resolveRemoteUrl } from "../shared/paths.js";
 import { createShellChannel } from "../shared/protocol.js";
 import {
@@ -41,6 +50,7 @@ const els = {
   settingsButton: document.querySelector("#settings-button"),
   settingsPopover: document.querySelector("#settings-popover"),
   settingsOverlay: document.querySelector("#settings-overlay"),
+  settingsOmekaVersion: document.querySelector("#settings-omeka-version"),
   settingsPhpVersion: document.querySelector("#settings-php-version"),
   settingsApply: document.querySelector("#settings-apply"),
   settingsCancel: document.querySelector("#settings-cancel"),
@@ -56,6 +66,8 @@ const els = {
 const scopeId = getOrCreateScopeId();
 let config;
 let currentRuntimeId;
+let currentPhpVersion = DEFAULT_PHP_VERSION;
+let currentOmekaVersion = DEFAULT_OMEKA_VERSION;
 let currentPath = "/";
 let channel;
 let serviceWorkerReady = null;
@@ -382,30 +394,58 @@ function bindServiceWorkerMessages() {
 }
 
 function populateSettingsModal() {
+  if (!els.settingsOmekaVersion || !els.settingsPhpVersion) {
+    return;
+  }
+
+  els.settingsOmekaVersion.innerHTML = "";
+  for (const entry of OMEKA_VERSIONS) {
+    const option = document.createElement("option");
+    option.value = entry.version;
+    option.textContent = entry.label;
+    els.settingsOmekaVersion.append(option);
+  }
+  els.settingsOmekaVersion.value = currentOmekaVersion;
+
+  updatePhpVersionDropdown(currentOmekaVersion);
+  els.settingsPhpVersion.value = currentPhpVersion;
+}
+
+function updatePhpVersionDropdown(omekaVersion) {
   if (!els.settingsPhpVersion) {
     return;
   }
 
+  const compatible = getCompatiblePhpVersions(omekaVersion);
+  const previousValue = els.settingsPhpVersion.value;
   els.settingsPhpVersion.innerHTML = "";
-  for (const runtime of config.runtimes) {
+  for (const version of compatible) {
     const option = document.createElement("option");
-    option.value = runtime.id;
-    option.textContent = runtime.label;
+    option.value = version;
+    option.textContent = `PHP ${version}`;
     els.settingsPhpVersion.append(option);
   }
-  els.settingsPhpVersion.value = currentRuntimeId;
+
+  if (compatible.includes(previousValue)) {
+    els.settingsPhpVersion.value = previousValue;
+  } else if (compatible.includes(currentPhpVersion)) {
+    els.settingsPhpVersion.value = currentPhpVersion;
+  } else if (compatible.includes(DEFAULT_PHP_VERSION)) {
+    els.settingsPhpVersion.value = DEFAULT_PHP_VERSION;
+  } else {
+    els.settingsPhpVersion.value = compatible[0];
+  }
 }
 
 function updateCurrentVersionLabels() {
+  const meta = getOmekaVersionMetadata(currentOmekaVersion);
   if (els.currentOmekaLabel) {
-    els.currentOmekaLabel.textContent =
-      config.omekaVersion || config.bundleVersion || "-";
+    els.currentOmekaLabel.textContent = meta
+      ? meta.label
+      : currentOmekaVersion || "-";
   }
   if (els.currentPhpLabel) {
-    const runtime = config.runtimes.find((r) => r.id === currentRuntimeId);
-    els.currentPhpLabel.textContent = runtime
-      ? runtime.label
-      : currentRuntimeId;
+    els.currentPhpLabel.textContent = `PHP ${currentPhpVersion}`;
   }
   if (els.currentRuntimeLabel) {
     els.currentRuntimeLabel.textContent = currentRuntimeId;
@@ -439,22 +479,29 @@ function closeSettingsPopover() {
 }
 
 function applySettingsAndReset() {
-  const newRuntimeId = els.settingsPhpVersion?.value;
+  const newOmeka = els.settingsOmekaVersion?.value;
+  const newPhp = els.settingsPhpVersion?.value;
   closeSettingsPopover();
 
-  if (newRuntimeId === currentRuntimeId) {
+  if (newOmeka === currentOmekaVersion && newPhp === currentPhpVersion) {
     return;
   }
 
-  currentRuntimeId = newRuntimeId;
-  remoteFrameBooted = false;
-  appendLog(`Switching runtime to ${currentRuntimeId}`);
-  updateCurrentVersionLabels();
-  saveState({ switchedAt: new Date().toISOString() });
-  serviceWorkerReady = null;
-  pendingCleanBoot = true;
-  setPhpInfoContent("");
-  void updateFrame();
+  // Persist the choice via URL params and reload. Reloading gives us a
+  // fresh WASM runtime, a fresh service worker registration, and rebuilds
+  // the scope so stale per-version state can't leak across version swaps.
+  const url = new URL(window.location.href);
+  if (newPhp) {
+    url.searchParams.set("php", newPhp);
+  }
+  if (newOmeka) {
+    url.searchParams.set("omeka", newOmeka);
+  }
+  url.searchParams.delete("phpVersion");
+  url.searchParams.delete("omekaVersion");
+  // Clear any saved session state so the new version boots fresh.
+  clearScopeSession(scopeId);
+  window.location.href = url.toString();
 }
 
 async function main() {
@@ -462,16 +509,33 @@ async function main() {
   activeBlueprint = await resolveBlueprintForShell(scopeId, config);
   updateBlueprintTextarea();
   const previous = loadSessionState(scopeId);
-  const defaultRuntime = getDefaultRuntime(config);
   const preferredPath =
     activeBlueprint?.landingPage || config.landingPath || "/";
   const shouldForceCleanBoot = pendingCleanBoot;
   const shouldBypassSavedLogin =
     config.autologin && previous?.path === "/login";
 
-  currentRuntimeId = shouldForceCleanBoot
-    ? defaultRuntime.id
-    : previous?.runtimeId || defaultRuntime.id;
+  // Resolve the runtime selection from (explicit URL params) >
+  // (active blueprint preferred versions) > (saved session) >
+  // (config defaults). On a forced clean boot we ignore the saved session
+  // so the runtime always matches the resolved selection.
+  const urlParams = parseQueryParams(window.location.href);
+  const selection = resolveRuntimeSelection({
+    php: urlParams.php || activeBlueprint?.preferredVersions?.php || undefined,
+    omeka:
+      urlParams.omeka || activeBlueprint?.preferredVersions?.omeka || undefined,
+    runtimeId: shouldForceCleanBoot
+      ? undefined
+      : previous?.runtimeId ||
+        config.runtimes?.find((r) => r.default)?.id ||
+        config.runtimes?.[0]?.id,
+  });
+  currentPhpVersion = selection.phpVersion;
+  currentOmekaVersion = selection.omekaVersion;
+  currentRuntimeId = selection.runtimeId;
+  appendLog(
+    `Runtime selection: php=${currentPhpVersion}, omeka=${currentOmekaVersion}, runtime=${currentRuntimeId}`,
+  );
   currentPath = shouldForceCleanBoot
     ? preferredPath
     : shouldBypassSavedLogin
@@ -480,6 +544,12 @@ async function main() {
   els.address.value = currentPath;
 
   updateCurrentVersionLabels();
+
+  if (els.settingsOmekaVersion) {
+    els.settingsOmekaVersion.addEventListener("change", (event) => {
+      updatePhpVersionDropdown(event.target.value);
+    });
+  }
 
   // Settings popover event listeners
   if (els.settingsButton) {

--- a/tests/omeka-versions.test.mjs
+++ b/tests/omeka-versions.test.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  ALL_PHP_VERSIONS,
+  buildManifestFilename,
+  buildRuntimeId,
+  buildRuntimeLabel,
+  DEFAULT_OMEKA_VERSION,
+  DEFAULT_PHP_VERSION,
+  getCompatiblePhpVersions,
+  getDefaultOmekaVersion,
+  getOmekaVersionMetadata,
+  isCompatibleCombination,
+  OMEKA_VERSIONS,
+  parseQueryParams,
+  parseRuntimeId,
+  resolveOmekaVersion,
+  resolveRuntimeConfig,
+  resolveRuntimeSelection,
+  resolveVersions,
+} from "../src/shared/omeka-versions.js";
+
+describe("OMEKA_VERSIONS", () => {
+  it("includes 4.1.1 and 4.2.0 and picks 4.2.0 as default", () => {
+    const versions = OMEKA_VERSIONS.map((entry) => entry.version);
+    assert.ok(versions.includes("4.1.1"));
+    assert.ok(versions.includes("4.2.0"));
+    assert.equal(getDefaultOmekaVersion().version, "4.2.0");
+    assert.equal(DEFAULT_OMEKA_VERSION, "4.2.0");
+  });
+
+  it("exposes the full PHP matrix and a sensible default", () => {
+    assert.deepEqual(ALL_PHP_VERSIONS, ["8.1", "8.2", "8.3", "8.4", "8.5"]);
+    assert.equal(DEFAULT_PHP_VERSION, "8.3");
+  });
+});
+
+describe("getOmekaVersionMetadata", () => {
+  it("matches by exact version string", () => {
+    assert.equal(getOmekaVersionMetadata("4.1.1")?.version, "4.1.1");
+    assert.equal(getOmekaVersionMetadata("4.2.0")?.version, "4.2.0");
+  });
+
+  it("returns null for unknown versions", () => {
+    assert.equal(getOmekaVersionMetadata("3.0"), null);
+    assert.equal(getOmekaVersionMetadata(null), null);
+  });
+});
+
+describe("resolveOmekaVersion", () => {
+  it("accepts exact version strings", () => {
+    assert.equal(resolveOmekaVersion("4.1.1"), "4.1.1");
+    assert.equal(resolveOmekaVersion("4.2.0"), "4.2.0");
+  });
+
+  it("resolves a major.minor request to the declared patch version", () => {
+    assert.equal(resolveOmekaVersion("4.1"), "4.1.1");
+    assert.equal(resolveOmekaVersion("4.2"), "4.2.0");
+  });
+
+  it("returns null for unknown input", () => {
+    assert.equal(resolveOmekaVersion("3.5"), null);
+    assert.equal(resolveOmekaVersion(""), null);
+    assert.equal(resolveOmekaVersion(undefined), null);
+  });
+});
+
+describe("getCompatiblePhpVersions / isCompatibleCombination", () => {
+  it("returns the declared PHP versions for each Omeka version", () => {
+    assert.deepEqual(getCompatiblePhpVersions("4.1.1"), [
+      "8.1",
+      "8.2",
+      "8.3",
+      "8.4",
+      "8.5",
+    ]);
+  });
+
+  it("detects invalid combinations", () => {
+    assert.equal(isCompatibleCombination("8.3", "4.1.1"), true);
+    assert.equal(isCompatibleCombination("7.4", "4.2.0"), false);
+    assert.equal(isCompatibleCombination("8.3", "nope"), false);
+  });
+});
+
+describe("buildRuntimeId / parseRuntimeId", () => {
+  it("round-trips modern runtime ids", () => {
+    const id = buildRuntimeId("8.3", "4.2.0");
+    assert.equal(id, "php83-omeka420");
+    assert.deepEqual(parseRuntimeId(id), {
+      phpVersion: "8.3",
+      omekaVersion: "4.2.0",
+    });
+
+    const id411 = buildRuntimeId("8.3", "4.1.1");
+    assert.equal(id411, "php83-omeka411");
+    assert.deepEqual(parseRuntimeId(id411), {
+      phpVersion: "8.3",
+      omekaVersion: "4.1.1",
+    });
+  });
+
+  it("maps legacy phpXY ids to the default Omeka version", () => {
+    assert.deepEqual(parseRuntimeId("php83"), {
+      phpVersion: "8.3",
+      omekaVersion: DEFAULT_OMEKA_VERSION,
+    });
+    assert.deepEqual(parseRuntimeId("php81-cgi"), {
+      phpVersion: "8.1",
+      omekaVersion: DEFAULT_OMEKA_VERSION,
+    });
+  });
+
+  it("returns null for unrecognised ids", () => {
+    assert.equal(parseRuntimeId(null), null);
+    assert.equal(parseRuntimeId("garbage"), null);
+  });
+});
+
+describe("resolveVersions / resolveRuntimeSelection", () => {
+  it("prefers explicit params over other inputs", () => {
+    assert.deepEqual(
+      resolveVersions({
+        php: "8.4",
+        omeka: "4.1.1",
+        runtimeId: "php83-omeka420",
+      }),
+      { phpVersion: "8.4", omekaVersion: "4.1.1" },
+    );
+  });
+
+  it("falls back to the runtime id when params are missing", () => {
+    assert.deepEqual(resolveVersions({ runtimeId: "php82-omeka411" }), {
+      phpVersion: "8.2",
+      omekaVersion: "4.1.1",
+    });
+  });
+
+  it("falls back to defaults when nothing is supplied", () => {
+    assert.deepEqual(resolveVersions({}), {
+      phpVersion: DEFAULT_PHP_VERSION,
+      omekaVersion: DEFAULT_OMEKA_VERSION,
+    });
+  });
+
+  it("drops incompatible explicit PHP versions", () => {
+    // PHP 7.4 is not in the compatibility list — the resolver should fall
+    // back to the Omeka version's default.
+    const resolved = resolveVersions({ php: "7.4", omeka: "4.2.0" });
+    assert.equal(resolved.omekaVersion, "4.2.0");
+    assert.notEqual(resolved.phpVersion, "7.4");
+  });
+
+  it("buildRuntimeLabel synthesises a readable label", () => {
+    assert.equal(buildRuntimeLabel("8.3", "4.1.1"), "PHP 8.3 + Omeka S 4.1.1");
+  });
+
+  it("resolveRuntimeSelection returns a consistent runtime id", () => {
+    const selection = resolveRuntimeSelection({ omeka: "4.1", php: "8.3" });
+    assert.equal(selection.omekaVersion, "4.1.1");
+    assert.equal(selection.phpVersion, "8.3");
+    assert.equal(selection.runtimeId, "php83-omeka411");
+  });
+});
+
+describe("resolveRuntimeConfig", () => {
+  const fakeConfig = {
+    runtimes: [
+      {
+        id: "php83-omeka420",
+        label: "PHP 8.3 + Omeka 4.2.0",
+        phpVersion: "8.3",
+        omekaVersion: "4.2.0",
+        default: true,
+      },
+      {
+        id: "php83-omeka411",
+        label: "PHP 8.3 + Omeka 4.1.1",
+        phpVersion: "8.3",
+        omekaVersion: "4.1.1",
+        default: false,
+      },
+    ],
+  };
+
+  it("returns the exact runtime entry when present", () => {
+    const resolved = resolveRuntimeConfig(fakeConfig, {
+      runtimeId: "php83-omeka420",
+    });
+    assert.equal(resolved.id, "php83-omeka420");
+    assert.equal(resolved.label, "PHP 8.3 + Omeka 4.2.0");
+  });
+
+  it("synthesises a runtime entry for unconfigured combinations", () => {
+    const resolved = resolveRuntimeConfig(fakeConfig, {
+      runtimeId: "php85-omeka420",
+    });
+    assert.equal(resolved.id, "php85-omeka420");
+    assert.equal(resolved.phpVersion, "8.5");
+    assert.equal(resolved.omekaVersion, "4.2.0");
+    assert.equal(
+      resolved.label,
+      "PHP 8.5 + Omeka S 4.2.0 (experimental SQLite)",
+    );
+  });
+
+  it("returns null when the config has no runtimes", () => {
+    assert.equal(resolveRuntimeConfig({ runtimes: [] }, {}), null);
+    assert.equal(resolveRuntimeConfig(null, {}), null);
+  });
+});
+
+describe("parseQueryParams", () => {
+  it("reads omeka/php params from a URL string", () => {
+    const parsed = parseQueryParams("https://example.com/?omeka=4.1.1&php=8.4");
+    assert.equal(parsed.omeka, "4.1.1");
+    assert.equal(parsed.php, "8.4");
+  });
+
+  it("reads from an existing URL object", () => {
+    const url = new URL("https://example.com/?omekaVersion=4.2.0");
+    const parsed = parseQueryParams(url);
+    assert.equal(parsed.omekaVersion, "4.2.0");
+  });
+});
+
+describe("buildManifestFilename", () => {
+  it("produces the declared manifest filename for each version", () => {
+    assert.equal(buildManifestFilename("4.1.1"), "4.1.1.json");
+    assert.equal(buildManifestFilename("4.2.0"), "4.2.0.json");
+  });
+
+  it("falls back to latest.json for unknown versions", () => {
+    assert.equal(buildManifestFilename("9.9.9"), "latest.json");
+  });
+});


### PR DESCRIPTION
## Summary

Brings moodle-playground-style multi-version support to this repo: the user can now choose between **Omeka S 4.2.0** (default — the experimental-SQLite feature branch we were already building) and **Omeka S 4.1.1** (upstream release ZIP) from the Settings dropdown, the URL, or the blueprint.

### Version selection precedence

URL params > blueprint `preferredVersions.omeka` > saved session > config default.

| How | Example |
| --- | --- |
| URL | `?omeka=4.1.1&php=8.3` (also accepts `omekaVersion=`, `phpVersion=`, `4.1`) |
| Blueprint | `{"preferredVersions": {"omeka": "4.1.1"}}` |
| Settings popover | "Omeka S Version" + "PHP Version" selects, reload on apply |

The PHP select auto-filters to the compatibility matrix declared in `src/shared/omeka-versions.js` whenever the Omeka version changes.

### Architecture

`src/shared/omeka-versions.js` is the single source of truth for every supported version. It's imported by:

- `scripts/build-omeka-bundle.sh` — dispatches to either `fetch-omeka-source.sh` (git) or the new `scripts/fetch-omeka-release.sh` (GitHub release ZIP) based on `source.type`.
- `lib/omeka-loader.js` + `src/runtime/manifest.js` — compute the per-version manifest URL at boot, falling back to `latest.json` if the versioned manifest is missing.
- `php-worker.js` — parses the runtime ID, synthesises a runtime config via `resolveRuntimeConfig` (no need to enumerate the full PHP × Omeka matrix in `playground.config.json`), and passes `omekaVersion` to `bootstrapOmeka` so the right bundle mounts.
- `src/shell/main.js` + `src/remote/main.js` — populate the dropdown, read URL params, honour blueprint preferred versions, and build a consistent runtime ID (`phpXY-omekaNNN`).

Runtime IDs now encode both versions (e.g. `php83-omeka420`, `php83-omeka411`). The old `phpXY` format still parses — it maps to the default Omeka version for backward compat.

### Build layout

- `assets/omeka/<version>/omeka-core-<release>.zip`
- `assets/manifests/<version>.json` (plus a `latest.json` alias for the default version)
- `make bundle OMEKA_VERSION=4.1.1` / `make bundle-4.1.1` / `make bundle-4.2.0` / `make bundle-all`
- CI now runs `make bundle-all` so both versions ship on every deploy.

Adding a third version later is a one-file change: append an entry to `OMEKA_VERSIONS` (and a per-version `make` target for convenience).

## Test plan

- [x] `make lint` — clean (the Biome schema-version info is pre-existing).
- [x] `make test` — 78/78 passing, including 25 new `tests/omeka-versions.test.mjs` cases covering the resolver, parser, compatibility matrix, and runtime-config synthesis.
- [x] `node --check` across every edited JS file.
- [x] `sh -n` across every shell script.
- [x] `npm run build-worker` — bundle builds cleanly.
- [x] `node scripts/generate-manifest.mjs` now tolerates a missing `--sourceCommit` (release ZIPs don't have one).
- [ ] Manual smoke test after deploy: boot both versions via the dropdown, via `?omeka=4.1.1`, and via a blueprint with `preferredVersions.omeka = "4.1.1"`, and confirm each boots the correct Omeka release.

## Caveats

- 4.1.1 is the upstream release ZIP, which does **not** include the experimental SQLite patch that 4.2.0 carries on the fork. Running 4.1.1 in the browser may surface driver-level issues the SQLite patch papers over; the build scaffolding is in place so we can later apply per-version patches if needed.
- The CI workflow will try to build both versions on the next deploy — the 4.1.1 build may need a follow-up if upstream composer install fails under the browser-bundle constraints.