### PR TITLE
Fix worker bundle resolving icu.dat from missing @php-wasm/intl

### DIFF
--- a/scripts/esbuild.worker.mjs
+++ b/scripts/esbuild.worker.mjs
@@ -1,6 +1,23 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
+import { dirname, resolve as resolvePath } from "node:path";
 import { build } from "esbuild";
+
+const require = createRequire(import.meta.url);
+
+// @php-wasm/web >= 3.1.22 references "../intl/shared/icu.dat", expecting a
+// sibling @php-wasm/intl package that is never published to npm. The file still
+// ships inside @php-wasm/web itself, so redirect the import to the existing copy.
+const phpWasmWebDir = dirname(require.resolve("@php-wasm/web/package.json"));
+const icuDatShim = {
+  name: "php-wasm-intl-icu-shim",
+  setup(api) {
+    api.onResolve({ filter: /\.\.\/intl\/shared\/icu\.dat$/ }, () => ({
+      path: resolvePath(phpWasmWebDir, "shared/icu.dat"),
+    }));
+  },
+};
 
 await build({
   entryPoints: ["php-worker.js"],
@@ -15,6 +32,7 @@ await build({
   banner: {
     js: `const __APP_ROOT__ = new URL("../", import.meta.url).href;`,
   },
+  plugins: [icuDatShim],
   loader: {
     ".wasm": "file",
     ".so": "file",


### PR DESCRIPTION
## Summary

- Failing CI run: https://github.com/ateeducacion/omeka-s-playground/actions/runs/25451825926
- `@php-wasm/web >= 3.1.22` dynamically imports `../intl/shared/icu.dat`, expecting a sibling `@php-wasm/intl` package that is never published to npm. esbuild rightly fails to resolve the path, so `npm run build-worker` (and therefore `make prepare`) breaks.
- The actual `icu.dat` file still ships inside `@php-wasm/web` itself (`node_modules/@php-wasm/web/shared/icu.dat`), so this adds a small esbuild `onResolve` plugin that redirects the broken relative import to the existing copy.

## Why a shim instead of pinning back to 3.1.21

This keeps Dependabot working on `@php-wasm/web` / `@php-wasm/universal` and survives future bumps until upstream republishes `@php-wasm/intl`.

## Test plan

- [x] `npm run build-worker` — succeeds, `dist/icu-*.dat` is emitted
- [x] `make lint`
- [x] `make test` — 78/78 pass
- [ ] CI green on this branch