### PR TITLE
fix(worker): patch @php-wasm/web tcp-over-fetch to allow HEAD without body

### DIFF
--- a/scripts/esbuild.worker.mjs
+++ b/scripts/esbuild.worker.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, resolve as resolvePath } from "node:path";
 import { build } from "esbuild";
@@ -19,6 +20,43 @@ const icuDatShim = {
   },
 };
 
+// @php-wasm/web's `tcp-over-fetch-websocket.ts` (lines around 643 upstream)
+// builds an outbound `ReadableStream` body for every request whose method is
+// not exactly "GET", then constructs `new Request(url, { method, body })`.
+// HEAD passes through that branch and the browser throws
+// `Failed to construct 'Request': Request with GET/HEAD method cannot have body`,
+// which surfaces as an uncaught promise rejection from PHP curl. The published
+// @php-wasm/web bundle minifies the variable to `S.method`, so we patch the
+// single occurrence to also exclude HEAD before esbuild ingests the file.
+// Filed upstream at WordPress/wordpress-playground; remove this plugin once
+// it lands in a published @php-wasm/web release.
+const phpWasmHeadBodyFixPlugin = {
+  name: "php-wasm-tcp-over-fetch-head-body-fix",
+  setup(b) {
+    const phpWasmWebIndex = resolvePath(phpWasmWebDir, "index.js");
+    b.onLoad({ filter: /@php-wasm\/web\/index\.js$/ }, async (args) => {
+      if (args.path !== phpWasmWebIndex) {
+        return null;
+      }
+      const source = await readFile(args.path, "utf8");
+      const pattern = /\bif\s*\(\s*S\.method\s*!==\s*"GET"\s*\)\s*\{/;
+      if (!pattern.test(source)) {
+        throw new Error(
+          "php-wasm-tcp-over-fetch-head-body-fix: pattern not found in "
+            + `${args.path}. The upstream bundle layout may have changed; `
+            + "verify parseHttpRequest() in @php-wasm/web/index.js and update "
+            + "the regex.",
+        );
+      }
+      const patched = source.replace(
+        pattern,
+        'if (S.method !== "GET" && S.method !== "HEAD") {',
+      );
+      return { contents: patched, loader: "js" };
+    });
+  },
+};
+
 await build({
   entryPoints: ["php-worker.js"],
   bundle: true,
@@ -32,7 +70,7 @@ await build({
   banner: {
     js: `const __APP_ROOT__ = new URL("../", import.meta.url).href;`,
   },
-  plugins: [icuDatShim],
+  plugins: [icuDatShim, phpWasmHeadBodyFixPlugin],
   loader: {
     ".wasm": "file",
     ".so": "file",

--- a/scripts/esbuild.worker.mjs
+++ b/scripts/esbuild.worker.mjs
@@ -42,10 +42,10 @@ const phpWasmHeadBodyFixPlugin = {
       const pattern = /\bif\s*\(\s*S\.method\s*!==\s*"GET"\s*\)\s*\{/;
       if (!pattern.test(source)) {
         throw new Error(
-          "php-wasm-tcp-over-fetch-head-body-fix: pattern not found in "
-            + `${args.path}. The upstream bundle layout may have changed; `
-            + "verify parseHttpRequest() in @php-wasm/web/index.js and update "
-            + "the regex.",
+          "php-wasm-tcp-over-fetch-head-body-fix: pattern not found in " +
+            `${args.path}. The upstream bundle layout may have changed; ` +
+            "verify parseHttpRequest() in @php-wasm/web/index.js and update " +
+            "the regex.",
         );
       }
       const patched = source.replace(


### PR DESCRIPTION
## Summary
- Ports [moodle-playground#93](https://github.com/ateeducacion/moodle-playground/pull/93) — adds an esbuild plugin that patches `@php-wasm/web/index.js` so HEAD requests do not carry a body
- Self-validating: the plugin throws at build time if the upstream pattern shifts (early-warning system for future `@php-wasm/web` bumps)
- Latent today (no PHP code in this repo currently emits HEAD via curl) but cheap insurance for any future module that uses `CURLOPT_NOBODY`, `get_headers()`, conditional probes, etc.

## Background
Upstream `@php-wasm/web`'s `parseHttpRequest()` attaches a `ReadableStream` body to any non-GET request and then constructs `new Request(url, { method, body })`. HEAD passes through that branch and the browser throws `Request with GET/HEAD method cannot have body`, surfacing as an uncaught rejection from PHP curl. First hit in moodle-playground when Moodle's URL repository did a HEAD probe on a remote file.

Will be removed once a fixed `@php-wasm/web` lands upstream (filed at WordPress/wordpress-playground).

## Test plan
- [x] `npm run build-worker` succeeds (the plugin throws if it cannot find the upstream pattern)
- [x] `grep '!== "GET" && S3.method !== "HEAD"' dist/php-worker.bundle.js` → 1 occurrence (after esbuild minification: `S3.method`)
- [ ] Smoke-boot the playground in a browser — confirm no regression in normal request flow
- [ ] (Optional) Manual HEAD probe from PHP via curl with `CURLOPT_NOBODY` to confirm it no longer rejects