### PR TITLE
Fix boot crash: Doctrine rejects setAutoGenerateProxyClasses(-1)

### DIFF
--- a/scripts/build-omeka-bundle.sh
+++ b/scripts/build-omeka-bundle.sh
@@ -114,6 +114,15 @@ perl -0pi -e "s/\\n\\\$this->headLink\\(\\)->prependStylesheet\\('\\/\\/fonts\\.
   "$OMEKA_STAGE/application/view/layout/layout.phtml" \
   "$OMEKA_STAGE/application/view/common/user-bar.phtml"
 
+# Omeka deliberately calls setAutoGenerateProxyClasses(-1) and relies on old
+# Doctrine silently ignoring out-of-range modes ("do nothing"). doctrine/common
+# >= 3.5 now validates the mode and throws "Invalid auto generate mode -1",
+# crashing boot before the EntityManager can be created. The pre-generated
+# proxies are shipped in the bundle, so AUTOGENERATE_NEVER (0) is the correct,
+# valid equivalent of the original "never regenerate" intent.
+perl -0pi -e "s/setAutoGenerateProxyClasses\\(-1\\)/setAutoGenerateProxyClasses(0)/" \
+  "$OMEKA_STAGE/application/src/Service/EntityManagerFactory.php"
+
 if [ ! -d "$OMEKA_STAGE/vendor" ]; then
   if command -v composer >/dev/null 2>&1; then
     composer install --working-dir="$OMEKA_STAGE" --no-dev --prefer-dist --no-progress --no-interaction --ignore-platform-reqs >&2

--- a/tests/build-omeka-bundle.test.mjs
+++ b/tests/build-omeka-bundle.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const scriptPath = fileURLToPath(
+  new URL("../scripts/build-omeka-bundle.sh", import.meta.url),
+);
+const script = readFileSync(scriptPath, "utf8");
+
+// Valid Doctrine proxy auto-generate modes (doctrine/common AUTOGENERATE_MODES).
+// Anything outside this set throws "Invalid auto generate mode" on >= 3.5.
+const VALID_AUTOGENERATE_MODES = new Set(["0", "1", "2", "3", "4"]);
+
+describe("build-omeka-bundle.sh doctrine proxy patch", () => {
+  it("rewrites Omeka's setAutoGenerateProxyClasses(-1) to a valid mode", () => {
+    // Omeka core ships this call relying on old Doctrine ignoring -1.
+    // doctrine/common >= 3.5 validates the mode and crashes boot otherwise.
+    // Strip shell/perl backslash escaping so the assertion ignores how many
+    // backslashes the regex needs and just checks the substitution intent.
+    const unescaped = script.replace(/\\/g, "");
+    assert.ok(
+      unescaped.includes(
+        "s/setAutoGenerateProxyClasses(-1)/setAutoGenerateProxyClasses(0)/",
+      ),
+      "build script must rewrite setAutoGenerateProxyClasses(-1) -> (0)",
+    );
+
+    // The replacement (right-hand side of the perl s///) must be a valid mode.
+    const replacementMatch = script.match(
+      /setAutoGenerateProxyClasses\((\d+)\)/,
+    );
+    assert.ok(
+      replacementMatch,
+      "build script must contain the replacement mode value",
+    );
+    assert.ok(
+      VALID_AUTOGENERATE_MODES.has(replacementMatch[1]),
+      `replacement mode ${replacementMatch[1]} must be a valid Doctrine AUTOGENERATE mode`,
+    );
+  });
+
+  it("the perl substitution turns the upstream call into a valid mode", () => {
+    // Mirror exactly what the build script runs against EntityManagerFactory.php.
+    const sample = "        $emConfig->setAutoGenerateProxyClasses(-1);\n";
+    const out = execFileSync(
+      "perl",
+      [
+        "-0pe",
+        "s/setAutoGenerateProxyClasses\\(-1\\)/setAutoGenerateProxyClasses(0)/",
+      ],
+      { input: sample },
+    ).toString();
+
+    assert.equal(out, "        $emConfig->setAutoGenerateProxyClasses(0);\n");
+    const mode = out.match(/setAutoGenerateProxyClasses\(([0-9-]+)\)/)[1];
+    assert.ok(VALID_AUTOGENERATE_MODES.has(mode));
+    assert.ok(!out.includes("(-1)"));
+  });
+});

--- a/tests/build-omeka-bundle.test.mjs
+++ b/tests/build-omeka-bundle.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 
 const scriptPath = fileURLToPath(
   new URL("../scripts/build-omeka-bundle.sh", import.meta.url),


### PR DESCRIPTION
## Problem

Loading the playground crashes on boot with:

```
PHP.run() failed with exit code 255
Doctrine\Common\Proxy\Exception\InvalidArgumentException: Invalid auto generate mode "-1" given
  ... EntityManagerFactory.php(106) -> EntityManager::create ...
Service with name "Omeka\EntityManager" could not be created.
```

## Root cause

Omeka core's `EntityManagerFactory` deliberately calls:

```php
// HACK: Doctrine takes an integer here and just happens to do nothing (which is
// what we want) if the number is not one of the defined proxy generation constants.
$emConfig->setAutoGenerateProxyClasses(-1);
```

Doctrine has validated this mode for a long time (it rejects anything outside `0..4`), so upstream Omeka makes `-1` work by shipping **patched override copies** of the Doctrine proxy classes under `application/data/overrides/` (`AbstractProxyFactory.php`, `ProxyFactory.php`, which allow `-1`) and `require_once`-ing them at the very top of `EntityManagerFactory::__invoke()`:

```php
require_once OMEKA_PATH . '/application/data/overrides/AbstractProxyFactory.php';
require_once OMEKA_PATH . '/application/data/overrides/ProxyFactory.php';
```

Loading them first pre-defines `Doctrine\ORM\Proxy\ProxyFactory` / `Doctrine\Common\Proxy\AbstractProxyFactory`, so the autoloader never pulls the stricter `vendor/` versions. The official Omeka S 4.2.0 release uses the same `doctrine/common 3.5.0` + `doctrine/orm 2.20.8` we do and boots fine because of this shim.

**The bundle source (`ateeducacion/omeka-s`, branch `feature/experimental-sqlite-support`) dropped those two `require_once` lines** from `EntityManagerFactory::__invoke()`. When CI rebuilds the bundle from that branch, the override classes are never loaded, the stricter `vendor/doctrine/orm/.../ProxyFactory.php` is used, and `-1` throws on boot. (Older committed bundles still had the lines, so this only surfaced after a fresh CI rebuild.)

The proper long-term fix belongs in the fork (restore the `require_once` shim). This PR adds a self-contained safety net in the playground build so a fork regression can't silently brick boot again.

## Fix

Patch the staged `application/src/Service/EntityManagerFactory.php` during the bundle build to rewrite `setAutoGenerateProxyClasses(-1)` -> `setAutoGenerateProxyClasses(0)`.

Mode `0` = `AUTOGENERATE_NEVER`, the valid, behavior-preserving equivalent of the original "never regenerate" intent. The bundle ships the 28 pre-generated proxy classes under `application/data/doctrine-proxies/`, and mode `0` is accepted by both the vendor and override `ProxyFactory`, so this works whether or not the override shim is present.

Verified by extracting the real bundled `EntityManagerFactory.php`, applying the exact perl substitution (`-1 -> 0`), and confirming `php -l` passes.

## Test

Adds `tests/build-omeka-bundle.test.mjs`:
- asserts the build script rewrites `setAutoGenerateProxyClasses(-1)` -> `(0)`
- asserts the replacement mode is a valid Doctrine `AUTOGENERATE` mode
- runs the exact perl substitution against a fixture and checks the output

Note: production deploys rebuild the (gitignored) bundle via CI, so a redeploy is required for the fix to reach the live site.