### PR TITLE
Support multiple sites, per-site permissions and per-user settings in blueprints

### DIFF
--- a/assets/blueprints/blueprint-schema.json
+++ b/assets/blueprints/blueprint-schema.json
@@ -65,9 +65,14 @@
           "password": { "type": "string", "minLength": 1 },
           "role": {
             "type": "string",
-            "enum": ["global_admin", "site_admin", "editor", "reviewer", "author", "researcher", "admin", "supervisor"]
+            "enum": ["global_admin", "site_admin", "editor", "reviewer", "author", "researcher", "admin", "supervisor", "site_editor"]
           },
-          "isActive": { "type": "boolean" }
+          "isActive": { "type": "boolean" },
+          "settings": {
+            "type": "object",
+            "description": "Per-user settings written to user_setting (e.g. limit_to_granted_sites).",
+            "additionalProperties": true
+          }
         }
       }
     },
@@ -191,6 +196,11 @@
             "type": "array",
             "items": { "type": "string" }
           },
+          "sites": {
+            "type": "array",
+            "description": "Slugs (or titles) of the sites this item is assigned to. Defaults to the default site.",
+            "items": { "type": "string" }
+          },
           "media": {
             "type": "array",
             "items": {
@@ -221,7 +231,41 @@
         "summary": { "type": "string" },
         "theme": { "type": "string" },
         "isPublic": { "type": "boolean" },
-        "setAsDefault": { "type": "boolean" }
+        "setAsDefault": { "type": "boolean" },
+        "permissions": { "$ref": "#/$defs/sitePermissions" }
+      }
+    },
+    "sites": {
+      "type": "array",
+      "description": "Multiple sites. When present, takes precedence over the singular \"site\".",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title"],
+        "properties": {
+          "title": { "type": "string" },
+          "slug": { "type": "string" },
+          "summary": { "type": "string" },
+          "theme": { "type": "string" },
+          "isPublic": { "type": "boolean" },
+          "setAsDefault": { "type": "boolean" },
+          "permissions": { "$ref": "#/$defs/sitePermissions" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sitePermissions": {
+      "type": "array",
+      "description": "Per-site user permissions, by user email.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["user"],
+        "properties": {
+          "user": { "type": "string", "description": "Email of an existing blueprint user." },
+          "role": { "type": "string", "enum": ["viewer", "editor", "admin"] }
+        }
       }
     }
   }

--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -19,10 +19,10 @@ The shell loads a blueprint, normalizes missing values, and stores the active ve
 
 - set install metadata such as title, locale, and timezone
 - create and authenticate the primary admin account
-- create additional users
+- create additional users and apply per-user settings
 - install or activate modules and themes
 - create item sets, items, and media
-- create a default public site
+- create one or more sites, assign per-site user permissions, and pick the default
 - choose the landing page after boot
 
 Because the blueprint influences first-boot behavior, a small JSON change can alter installation, login, routing, or demo content.
@@ -40,12 +40,13 @@ The most important top-level properties are:
 | `landingPage` | Initial post-boot path | Should usually begin with `/` |
 | `siteOptions` | Install-wide defaults | Title, locale, timezone |
 | `login` | Credentials used by autologin | Usually mirror the first user |
-| `users` | Omeka users to create | First user becomes the effective admin source |
+| `users` | Omeka users to create | First user becomes the effective admin source; each may carry `settings` |
 | `themes` | Themes to install | Supports bundled, URL, and `omeka.org` sources |
 | `modules` | Modules to install or activate | Module names must stay unique |
 | `itemSets` | Collections created before items | Referenced by item titles later |
-| `items` | Sample resources and media | Media currently uses URL sources |
-| `site` | Default public site | Optional but recommended for demos |
+| `items` | Sample resources and media | Media currently uses URL sources; `items[].sites` assigns sites by slug |
+| `site` | A single public site | Optional; legacy shorthand for a one-entry `sites` |
+| `sites` | One or more public sites with per-site permissions | Takes precedence over `site`; one is the default |
 
 ## Example
 
@@ -112,6 +113,57 @@ The most important top-level properties are:
 }
 ```
 
+## Multiple sites, permissions, and per-user settings
+
+Use the `sites` array to provision more than one site and to grant users access
+to specific sites. This is what makes access-control modules such as
+[IsolatedSites](https://github.com/ateeducacion/omeka-s-IsolatedSites) testable
+in the browser: give a user a per-site role, flip a per-user setting, and assign
+items to individual sites.
+
+- `sites[]` accepts the same fields as the singular `site` (`title`, `slug`,
+  `summary`, `theme`, `isPublic`, `setAsDefault`) plus `permissions`.
+- `sites[].permissions[]` grants an existing blueprint **user** (by email) a
+  site role of `viewer`, `editor`, or `admin`.
+- Exactly one site is the default. If no entry sets `setAsDefault: true`, the
+  first one is used. The legacy singular `site` still works and is treated as a
+  one-entry `sites` list (keeping its historical default of `setAsDefault: true`).
+- `users[].settings` is an object written verbatim to each user's settings
+  (`user_setting`), e.g. `limit_to_granted_sites`.
+- `items[].sites` lists the site slugs (titles are also accepted and slugified)
+  an item is assigned to. Without it, items go to the default site.
+
+```json
+{
+  "users": [
+    { "username": "admin", "email": "admin@example.com", "password": "password", "role": "global_admin" },
+    {
+      "username": "editor_a",
+      "email": "editor.a@example.com",
+      "password": "password",
+      "role": "site_editor",
+      "settings": { "limit_to_granted_sites": true, "limit_to_own_assets": true }
+    }
+  ],
+  "sites": [
+    {
+      "title": "Site A",
+      "slug": "site-a",
+      "setAsDefault": true,
+      "permissions": [{ "user": "editor.a@example.com", "role": "admin" }]
+    },
+    { "title": "Site B", "slug": "site-b" }
+  ],
+  "items": [
+    { "title": "Doc A1", "sites": ["site-a"] },
+    { "title": "Doc B1", "sites": ["site-b"] }
+  ]
+}
+```
+
+With this blueprint, signing in as `editor.a@example.com` (with IsolatedSites
+active) shows only Site A and its items, while the admin keeps full visibility.
+
 ## Example file for Common + EasyAdmin
 
 There is a ready-to-copy example at:
@@ -151,6 +203,10 @@ These conventions come from the current implementation, not generic JSON style a
 - Remote addon URLs are absolutized against the current page URL.
 - `modules[].state` currently supports `install` and `activate`.
 - `items[].media[].type` currently supports `url`.
+- `sites` takes precedence over the singular `site`; exactly one site is forced to be the default (the first one if none is flagged), and duplicate site slugs are rejected.
+- `sites[].permissions[].role` is clamped to one of `viewer`, `editor`, `admin` (defaults to `viewer`); a permission whose `user` email matches no created user is skipped with a warning.
+- `items[].sites` entries are slugified to match site slugs; items with no match fall back to the default site.
+- `users[].settings` keys are written verbatim to `user_setting`; values are stored as-is.
 
 If you change the semantics of any of those rules, update both the schema and the documentation together.
 

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -608,8 +608,15 @@ if (!$users) {
   ]];
 }
 
+$userSettingsService = $serviceManager->get('Omeka\\\\Settings\\\\User');
 foreach ($users as $userSpec) {
-  $upsertUser($userSpec);
+  $user = $upsertUser($userSpec);
+  if ($user && !empty($userSpec['settings']) && is_array($userSpec['settings'])) {
+    $userSettingsService->setTargetId($user->getId());
+    foreach ($userSpec['settings'] as $settingKey => $settingValue) {
+      $userSettingsService->set($settingKey, $settingValue);
+    }
+  }
 }
 
 $primaryAdmin = $ensureAdminIdentity($users[0]['email'] ?? '${config.admin.email}');
@@ -673,9 +680,21 @@ if ($shouldRerunBootstrap) {
   exit(0);
 }
 
-$siteSpec = $blueprint['site'] ?? null;
-$siteResource = null;
-if (is_array($siteSpec) && !empty($siteSpec['title'])) {
+// Support a list of sites (with per-user permissions); fall back to the legacy
+// singular "site" key for backward compatibility.
+$siteSpecs = $blueprint['sites'] ?? [];
+if (!$siteSpecs && is_array($blueprint['site'] ?? null)) {
+  $siteSpecs = [$blueprint['site']];
+}
+
+$siteRepo = $entityManager->getRepository(Omeka\\Entity\\Site::class);
+$siteIdsBySlug = [];
+$defaultSiteId = null;
+foreach ($siteSpecs as $siteSpec) {
+  if (!is_array($siteSpec) || empty($siteSpec['title'])) {
+    continue;
+  }
+
   $themeName = trim((string) ($siteSpec['theme'] ?? 'default'));
   if (!$themeManager->getTheme($themeName)) {
     $themeSpec = $themeSpecsByName[$themeName] ?? null;
@@ -688,11 +707,11 @@ if (is_array($siteSpec) && !empty($siteSpec['title'])) {
     $themeName = 'default';
   }
 
-  $siteRepo = $entityManager->getRepository(Omeka\\Entity\\Site::class);
-  $site = $siteRepo->findOneBy(['slug' => $siteSpec['slug']]);
+  $slug = trim((string) ($siteSpec['slug'] ?? ''));
+  $site = $slug !== '' ? $siteRepo->findOneBy(['slug' => $slug]) : null;
   $payload = [
     'o:title' => $siteSpec['title'],
-    'o:slug' => $siteSpec['slug'],
+    'o:slug' => $slug,
     'o:theme' => $themeName,
     'o:is_public' => array_key_exists('isPublic', $siteSpec) ? (bool) $siteSpec['isPublic'] : true,
     'o:item_pool' => [],
@@ -701,17 +720,50 @@ if (is_array($siteSpec) && !empty($siteSpec['title'])) {
     $payload['o:summary'] = $siteSpec['summary'];
   }
 
-  if ($site) {
-    $apiManager->update('sites', $site->getId(), $payload, [], ['isPartial' => true]);
-    $siteResponse = $apiManager->read('sites', $site->getId());
-  } else {
-    $siteResponse = $apiManager->create('sites', $payload);
+  // Grant per-site permissions to users referenced by email.
+  $sitePermissions = [];
+  foreach (($siteSpec['permissions'] ?? []) as $permission) {
+    $permissionEmail = trim((string) ($permission['user'] ?? ''));
+    if ($permissionEmail === '') {
+      continue;
+    }
+    $permissionUser = $findUserByEmail($permissionEmail);
+    if (!$permissionUser) {
+      $warnings[] = sprintf('Site "%s" permission skipped: user "%s" was not found.', $siteSpec['title'], $permissionEmail);
+      continue;
+    }
+    $sitePermissions[] = [
+      'o:user' => ['o:id' => $permissionUser->getId()],
+      'o:role' => trim((string) ($permission['role'] ?? 'viewer')) ?: 'viewer',
+    ];
+  }
+  if ($sitePermissions) {
+    $payload['o:site_permission'] = $sitePermissions;
   }
 
-  $siteResource = $siteResponse->getContent();
-  if (!empty($siteSpec['setAsDefault'])) {
-    $settings->set('default_site', $siteResource->id());
+  try {
+    if ($site) {
+      $apiManager->update('sites', $site->getId(), $payload, [], ['isPartial' => true]);
+      $siteResponse = $apiManager->read('sites', $site->getId());
+    } else {
+      $siteResponse = $apiManager->create('sites', $payload);
+    }
+
+    $siteResource = $siteResponse->getContent();
+    $siteIdsBySlug[$siteResource->slug()] = $siteResource->id();
+    $debug(sprintf('Provisioned site "%s" (#%s).', $siteSpec['title'], $siteResource->id()));
+
+    if (!empty($siteSpec['setAsDefault'])) {
+      $defaultSiteId = $siteResource->id();
+      $settings->set('default_site', $defaultSiteId);
+    }
+  } catch (Throwable $e) {
+    $warnings[] = sprintf('Unable to provision site "%s": %s', $siteSpec['title'], $describeThrowable($e));
   }
+}
+
+if (!$defaultSiteId && $siteIdsBySlug) {
+  $defaultSiteId = reset($siteIdsBySlug);
 }
 
 $ensureCoreVocabulary();
@@ -797,8 +849,18 @@ foreach (($blueprint['items'] ?? []) as $itemSpec) {
     $payload['o:item_set'] = $itemSetIds;
   }
 
-  if ($siteResource) {
-    $payload['o:site'] = [['o:id' => $siteResource->id()]];
+  $itemSiteIds = [];
+  foreach (($itemSpec['sites'] ?? []) as $itemSiteSlug) {
+    $itemSiteSlug = trim((string) $itemSiteSlug);
+    if ($itemSiteSlug !== '' && isset($siteIdsBySlug[$itemSiteSlug])) {
+      $itemSiteIds[] = ['o:id' => $siteIdsBySlug[$itemSiteSlug]];
+    }
+  }
+  if (!$itemSiteIds && $defaultSiteId) {
+    $itemSiteIds[] = ['o:id' => $defaultSiteId];
+  }
+  if ($itemSiteIds) {
+    $payload['o:site'] = $itemSiteIds;
   }
 
   try {

--- a/src/shared/blueprint.js
+++ b/src/shared/blueprint.js
@@ -110,6 +110,109 @@ function slugify(value, fallback = "playground") {
   return slug || fallback;
 }
 
+const SITE_PERMISSION_ROLES = ["viewer", "editor", "admin"];
+
+function normalizeSitePermissions(input) {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input
+    .map((permission) => {
+      const user = String(permission?.user || permission?.email || "").trim();
+      if (!user) {
+        return null;
+      }
+
+      const role = String(permission?.role || "viewer")
+        .trim()
+        .toLowerCase();
+
+      return {
+        user,
+        role: SITE_PERMISSION_ROLES.includes(role) ? role : "viewer",
+      };
+    })
+    .filter(Boolean);
+}
+
+function normalizeSiteSpec(site, fallbackTitle) {
+  if (!site || typeof site !== "object" || Array.isArray(site)) {
+    return null;
+  }
+
+  const title = String(site.title || fallbackTitle || "").trim();
+  if (!title) {
+    return null;
+  }
+
+  return {
+    title,
+    slug: slugify(site.slug || site.title || fallbackTitle),
+    summary: typeof site.summary === "string" ? site.summary : "",
+    theme: String(site.theme || "default").trim(),
+    isPublic: site.isPublic !== false,
+    setAsDefault: site.setAsDefault === true,
+    permissions: normalizeSitePermissions(site.permissions),
+  };
+}
+
+function normalizeUserSettings(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {};
+  }
+
+  const settings = {};
+  for (const [key, value] of Object.entries(input)) {
+    const settingKey = String(key).trim();
+    if (settingKey) {
+      settings[settingKey] = value;
+    }
+  }
+  return settings;
+}
+
+function normalizeSites(blueprint, fallbackTitle) {
+  let sites = [];
+
+  if (Array.isArray(blueprint.sites) && blueprint.sites.length > 0) {
+    // Multi-site mode: setAsDefault defaults to false per entry.
+    sites = blueprint.sites
+      .map((site) => normalizeSiteSpec(site))
+      .filter(Boolean);
+  } else if (
+    blueprint.site &&
+    typeof blueprint.site === "object" &&
+    !Array.isArray(blueprint.site)
+  ) {
+    // Single-site mode: keep the historical setAsDefault default of true.
+    const single = normalizeSiteSpec(blueprint.site, fallbackTitle);
+    if (single) {
+      single.setAsDefault = blueprint.site.setAsDefault !== false;
+      sites = [single];
+    }
+  }
+
+  // Reject duplicate slugs so site/permission assignments stay unambiguous.
+  const seenSlugs = new Set();
+  for (const site of sites) {
+    if (seenSlugs.has(site.slug)) {
+      throw new Error(
+        `Blueprint sites cannot include duplicate slug "${site.slug}".`,
+      );
+    }
+    seenSlugs.add(site.slug);
+  }
+
+  // Guarantee exactly one default site so items without an explicit site land
+  // somewhere predictable.
+  if (sites.length > 0 && !sites.some((site) => site.setAsDefault)) {
+    sites[0].setAsDefault = true;
+  }
+
+  return sites;
+}
+
 function normalizeAddonSource(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     return { type: "bundled" };
@@ -312,29 +415,15 @@ export function normalizeBlueprint(input, config) {
         index === 0 ? "global_admin" : "researcher",
       ),
       isActive: user?.isActive !== false,
+      settings: normalizeUserSettings(user?.settings),
     };
   });
 
+  const sites = normalizeSites(blueprint, fallback.siteOptions.title);
+  // `site` (singular) is kept for backward compatibility and resolves to the
+  // default site (or the first one) so existing consumers keep working.
   const activeSite =
-    blueprint.site && typeof blueprint.site === "object"
-      ? {
-          title: String(
-            blueprint.site.title || fallback.siteOptions.title,
-          ).trim(),
-          slug: slugify(
-            blueprint.site.slug ||
-              blueprint.site.title ||
-              fallback.siteOptions.title,
-          ),
-          summary:
-            typeof blueprint.site.summary === "string"
-              ? blueprint.site.summary
-              : "",
-          theme: String(blueprint.site.theme || "default").trim(),
-          isPublic: blueprint.site.isPublic !== false,
-          setAsDefault: blueprint.site.setAsDefault !== false,
-        }
-      : null;
+    sites.find((site) => site.setAsDefault) || sites[0] || null;
 
   return {
     $schema:
@@ -371,6 +460,7 @@ export function normalizeBlueprint(input, config) {
     },
     users: normalizedUsers,
     site: activeSite,
+    sites,
     themes: normalizeAddonCollection(blueprint.themes, "theme"),
     modules: normalizeAddonCollection(blueprint.modules, "module"),
     itemSets: Array.isArray(blueprint.itemSets)
@@ -394,6 +484,11 @@ export function normalizeBlueprint(input, config) {
             itemSets: Array.isArray(item?.itemSets)
               ? item.itemSets
                   .map((entry) => String(entry || "").trim())
+                  .filter(Boolean)
+              : [],
+            sites: Array.isArray(item?.sites)
+              ? item.sites
+                  .map((entry) => slugify(String(entry || ""), ""))
                   .filter(Boolean)
               : [],
             media: Array.isArray(item?.media)

--- a/tests/blueprint.test.mjs
+++ b/tests/blueprint.test.mjs
@@ -216,6 +216,131 @@ describe("normalizeBlueprint", () => {
   it("sets site to null when not provided", () => {
     const result = normalizeBlueprint({}, baseConfig);
     assert.equal(result.site, null);
+    assert.deepEqual(result.sites, []);
+  });
+
+  it("keeps single site backward compatibility (site + sites[0])", () => {
+    const result = normalizeBlueprint(
+      { site: { title: "My Site", theme: "classic" } },
+      baseConfig,
+    );
+    assert.equal(result.sites.length, 1);
+    assert.equal(result.sites[0].slug, "my-site");
+    // Single-site mode keeps the historical setAsDefault default of true.
+    assert.equal(result.sites[0].setAsDefault, true);
+    assert.equal(result.site.slug, "my-site");
+  });
+
+  it("normalizes a sites array and picks the default", () => {
+    const result = normalizeBlueprint(
+      {
+        sites: [
+          { title: "Site A", slug: "site-a" },
+          { title: "Site B", slug: "site-b", setAsDefault: true },
+        ],
+      },
+      baseConfig,
+    );
+    assert.equal(result.sites.length, 2);
+    assert.equal(result.sites[0].setAsDefault, false);
+    assert.equal(result.sites[1].setAsDefault, true);
+    // `site` (singular) resolves to the default site.
+    assert.equal(result.site.slug, "site-b");
+  });
+
+  it("defaults the first site when no setAsDefault is given in a sites array", () => {
+    const result = normalizeBlueprint(
+      { sites: [{ title: "Site A" }, { title: "Site B" }] },
+      baseConfig,
+    );
+    assert.equal(result.sites[0].setAsDefault, true);
+    assert.equal(result.sites[1].setAsDefault, false);
+    assert.equal(result.site.slug, "site-a");
+  });
+
+  it("prefers the sites array over the singular site", () => {
+    const result = normalizeBlueprint(
+      {
+        site: { title: "Legacy" },
+        sites: [{ title: "New Site", slug: "new-site" }],
+      },
+      baseConfig,
+    );
+    assert.equal(result.sites.length, 1);
+    assert.equal(result.site.slug, "new-site");
+  });
+
+  it("throws on duplicate site slugs", () => {
+    assert.throws(
+      () =>
+        normalizeBlueprint(
+          {
+            sites: [
+              { title: "A", slug: "dup" },
+              { title: "B", slug: "dup" },
+            ],
+          },
+          baseConfig,
+        ),
+      /duplicate slug/u,
+    );
+  });
+
+  it("normalizes site permissions and clamps unknown roles", () => {
+    const result = normalizeBlueprint(
+      {
+        sites: [
+          {
+            title: "Site A",
+            permissions: [
+              { user: "a@example.com", role: "Admin" },
+              { email: "b@example.com", role: "weird" },
+              { role: "editor" },
+            ],
+          },
+        ],
+      },
+      baseConfig,
+    );
+    const perms = result.sites[0].permissions;
+    assert.equal(perms.length, 2);
+    assert.deepEqual(perms[0], { user: "a@example.com", role: "admin" });
+    assert.deepEqual(perms[1], { user: "b@example.com", role: "viewer" });
+  });
+
+  it("normalizes per-user settings", () => {
+    const result = normalizeBlueprint(
+      {
+        users: [
+          {
+            email: "a@b.com",
+            password: "pass",
+            settings: { limit_to_granted_sites: true, junk: "" },
+          },
+        ],
+      },
+      baseConfig,
+    );
+    assert.equal(result.users[0].settings.limit_to_granted_sites, true);
+    assert.equal(result.users[0].settings.junk, "");
+  });
+
+  it("defaults user settings to an empty object", () => {
+    const result = normalizeBlueprint(
+      { users: [{ email: "a@b.com", password: "pass" }] },
+      baseConfig,
+    );
+    assert.deepEqual(result.users[0].settings, {});
+  });
+
+  it("normalizes item site assignments to slugs", () => {
+    const result = normalizeBlueprint(
+      {
+        items: [{ title: "Item 1", sites: ["Site A", "site-b", ""] }],
+      },
+      baseConfig,
+    );
+    assert.deepEqual(result.items[0].sites, ["site-a", "site-b"]);
   });
 });
 


### PR DESCRIPTION
## Summary

The blueprint provisioner only created a **single** `site`, with no site permissions and no per-user settings. That makes access-control modules — e.g. [IsolatedSites](https://github.com/ateeducacion/omeka-s-IsolatedSites) — impossible to demo in the browser, since their whole behaviour depends on *which sites a user is granted on*.

This adds first-class multi-site support to the blueprint format.

## What's new

- **`sites[]`** — provision multiple sites. Each entry takes the same fields as the singular `site` (`title`, `slug`, `summary`, `theme`, `isPublic`, `setAsDefault`) plus **`permissions[]`**: `{ "user": "<email>", "role": "viewer|editor|admin" }`.
  - Exactly one site is the default (the first if none sets `setAsDefault`).
  - Duplicate slugs are rejected.
  - The legacy singular **`site`** still works and is treated as a one-entry `sites` list (keeping its historical `setAsDefault: true` default), so existing blueprints are unaffected.
- **`users[].settings`** — an object written verbatim to each user's `user_setting` store (e.g. `limit_to_granted_sites`), applied through `Omeka\Settings\User`.
- **`items[].sites`** — assign items to specific sites by slug (titles are accepted and slugified). Items with no match fall back to the default site (previous behaviour).

### Example

```json
{
  "users": [
    { "email": "admin@example.com", "password": "password", "role": "global_admin" },
    { "email": "editor.a@example.com", "password": "password", "role": "site_editor",
      "settings": { "limit_to_granted_sites": true } }
  ],
  "sites": [
    { "title": "Site A", "slug": "site-a", "setAsDefault": true,
      "permissions": [{ "user": "editor.a@example.com", "role": "admin" }] },
    { "title": "Site B", "slug": "site-b" }
  ],
  "items": [
    { "title": "Doc A1", "sites": ["site-a"] },
    { "title": "Doc B1", "sites": ["site-b"] }
  ]
}
```

## Changes

- `src/shared/blueprint.js` — normalizes `sites`, site `permissions`, `users[].settings`, `items[].sites`; keeps `site` (singular) resolving to the default site for backward compatibility.
- `src/runtime/bootstrap.js` — loops over `sites`, hydrates `o:site_permission`, applies user settings, builds a slug→id map and assigns `o:site` per item.
- `assets/blueprints/blueprint-schema.json` — adds `sites`, `permissions` (`$defs`), `users[].settings`, `items[].sites`; adds `site_editor` to the role enum.
- `docs/blueprint-json.md` — documents the new fields, conventions and an end-to-end example.
- `tests/blueprint.test.mjs` — 9 new normalizer cases.

## Testing

- `make test` → **89 pass / 0 fail** (9 new blueprint cases).
- `node --check src/shared/blueprint.js src/runtime/bootstrap.js` → OK.
- `make lint` (Biome) → clean (exit 0).

The JS normalizer is unit-tested. The generated PHP provisioning (multi-site creation, `o:site_permission`, user settings) runs in the in-browser runtime and should be smoke-tested in the playground with a multi-site blueprint.