### PR TITLE
Create blueprint users after modules so module-defined roles validate

### DIFF
--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -597,33 +597,6 @@ if (!$status->isInstalled()) {
 
 $ensureAdminIdentity('${config.admin.email}');
 
-$users = $blueprint['users'] ?? [];
-if (!$users) {
-  $users = [[
-    'username' => '${config.admin.username}',
-    'email' => '${config.admin.email}',
-    'password' => '${config.admin.password}',
-    'role' => 'global_admin',
-    'isActive' => true,
-  ]];
-}
-
-$userSettingsService = $serviceManager->get('Omeka\\\\Settings\\\\User');
-foreach ($users as $userSpec) {
-  $user = $upsertUser($userSpec);
-  if ($user && !empty($userSpec['settings']) && is_array($userSpec['settings'])) {
-    $userSettingsService->setTargetId($user->getId());
-    foreach ($userSpec['settings'] as $settingKey => $settingValue) {
-      $userSettingsService->set($settingKey, $settingValue);
-    }
-  }
-}
-
-$primaryAdmin = $ensureAdminIdentity($users[0]['email'] ?? '${config.admin.email}');
-if (!$primaryAdmin) {
-  throw new RuntimeException('Unable to establish a global admin identity for blueprint provisioning.');
-}
-
 $settings->set('administrator_email', '${config.admin.email}');
 $settings->set('installation_title', '${config.siteTitle}');
 $settings->set('locale', '${config.locale}');
@@ -678,6 +651,36 @@ if ($shouldRerunBootstrap) {
     echo "[warning] " . $warning . "\\n";
   }
   exit(0);
+}
+
+// Create blueprint users only after all modules are installed and active, so
+// module-defined roles (e.g. IsolatedSites' "site_editor") are registered and
+// pass user validation, and apply each user's per-user settings.
+$users = $blueprint['users'] ?? [];
+if (!$users) {
+  $users = [[
+    'username' => '${config.admin.username}',
+    'email' => '${config.admin.email}',
+    'password' => '${config.admin.password}',
+    'role' => 'global_admin',
+    'isActive' => true,
+  ]];
+}
+
+$userSettingsService = $serviceManager->get('Omeka\\\\Settings\\\\User');
+foreach ($users as $userSpec) {
+  $user = $upsertUser($userSpec);
+  if ($user && !empty($userSpec['settings']) && is_array($userSpec['settings'])) {
+    $userSettingsService->setTargetId($user->getId());
+    foreach ($userSpec['settings'] as $settingKey => $settingValue) {
+      $userSettingsService->set($settingKey, $settingValue);
+    }
+  }
+}
+
+$primaryAdmin = $ensureAdminIdentity($users[0]['email'] ?? '${config.admin.email}');
+if (!$primaryAdmin) {
+  throw new RuntimeException('Unable to establish a global admin identity for blueprint provisioning.');
 }
 
 // Support a list of sites (with per-user permissions); fall back to the legacy


### PR DESCRIPTION
## Summary

Follow-up to #65. Blueprint users were created **before** the module install/activate loop. That breaks any user whose role is registered by a module — e.g. IsolatedSites' `site_editor`: on the first pass the module isn't active yet, the role isn't registered in the ACL, and Omeka's user validation rejects the create, aborting boot.

This moves blueprint user creation (and per-user `settings`) to **after** the module loop and its rerun-exit, i.e. to the final pass when every requested module is installed/active and its roles are registered.

## Why it's safe

- The admin identity used for module installs is still established up front from the core-created admin (`ensureAdminIdentity(config.admin.email)`), and the install-wide `settings` and MVC controller context are still set before the module loop.
- The bootstrap reruns once per module install/activation; on those passes it exits before the (now-later) user block, so users are created exactly once, on the final pass — when `site_editor` and friends are valid.
- Site permissions and items reference users by email and are provisioned after this block, so the users exist when needed.

## Testing

- `make test` → 89 pass / 0 fail
- `node --check` on both runtime files → OK
- `make lint` (Biome) → clean

Needs an in-browser smoke test with a blueprint that defines a `site_editor` user (e.g. the IsolatedSites demo).