### PR TITLE
fix(security): backport ZIP-slip + reflected XSS hardening from moodle audit

### DIFF
--- a/lib/omeka-loader.js
+++ b/lib/omeka-loader.js
@@ -154,6 +154,26 @@ export async function resolveBootstrapArchive(options = {}, onProgress) {
 }
 
 /**
+ * Sanitize a ZIP entry path to prevent ZIP-slip (path traversal). Normalizes
+ * "\\" to "/" (Windows-built archives), strips leading slashes, and drops empty
+ * and "." segments. Returns null when the entry contains a ".." segment (so the
+ * caller can skip it) — without this a crafted archive could write outside the
+ * target root via entries like "../../evil".
+ */
+export function sanitizeArchivePath(rawPath) {
+  const segments = String(rawPath)
+    .replaceAll("\\", "/")
+    .split("/")
+    .filter((segment) => segment !== "" && segment !== ".");
+
+  if (segments.some((segment) => segment === "..")) {
+    return null;
+  }
+
+  return segments.length > 0 ? segments.join("/") : null;
+}
+
+/**
  * Extract ZIP entries using fflate, normalize paths, strip leading folder.
  */
 export function extractZipEntries(zipBytes) {
@@ -182,7 +202,11 @@ export function extractZipEntries(zipBytes) {
     }
     const path = prefix ? rawPath.slice(prefix.length) : rawPath;
     if (!path) continue;
-    entries.push({ path, data });
+    // Reject ZIP-slip: skip entries that escape the target root via ".." or
+    // absolute paths so extraction can never write outside targetRoot.
+    const safePath = sanitizeArchivePath(path);
+    if (!safePath) continue;
+    entries.push({ path: safePath, data });
   }
 
   return entries;

--- a/sw.js
+++ b/sw.js
@@ -250,6 +250,15 @@ function getScopedBasePath(scopeId, runtimeId) {
   return withAppBasePath(`/playground/${scopeId}/${runtimeId}`);
 }
 
+function escapeHtml(str) {
+  return String(str)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
 function decodeHtmlAttributeEntities(value) {
   return value
     .replace(/&#x([0-9a-f]+);/giu, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
@@ -316,7 +325,12 @@ function rewriteHtmlAttributeUrl(rawValue, { origin, scopeId, runtimeId }) {
 function rewriteHtmlDocument(html, scope) {
   return html.replace(
     /((?:href|src|action|data-[\w-]*url|data-url|data-action)=["'])([^"']*)(["'])/giu,
-    (match, prefix, rawValue, suffix) => `${prefix}${rewriteHtmlAttributeUrl(rawValue, scope)}${suffix}`,
+    // rewriteHtmlAttributeUrl returns a *decoded* URL (entities turned back
+    // into raw &, ", <, > characters). Re-encode it for HTML attribute context
+    // before interpolating it back between the quotes, otherwise a decoded
+    // value containing a quote could close the attribute early and inject HTML
+    // into the playground iframe (reflected XSS).
+    (match, prefix, rawValue, suffix) => `${prefix}${escapeHtml(rewriteHtmlAttributeUrl(rawValue, scope))}${suffix}`,
   );
 }
 


### PR DESCRIPTION
Two security findings from the [moodle-playground](https://github.com/erseco/moodle-playground) multi-agent audit also apply to this shared-architecture codebase. Both fixes are self-contained and behaviour-preserving for legitimate input.

## 1. ZIP-slip path traversal (`lib/omeka-loader.js`)
`extractZipEntries()` produced `entry.path` straight from the archive (after stripping a common prefix), and `writeEntriesToPhp()` then wrote `${targetRoot}/${entry.path}`. A crafted ZIP entry like `../../evil` could escape `targetRoot` and overwrite arbitrary files in the Emscripten FS.

**Fix:** add `sanitizeArchivePath()` (normalizes `\\`→`/`, drops `.`/empty segments, returns `null` on any `..` segment) and skip unsafe entries at the single extraction chokepoint that feeds all FS writes.

## 2. Reflected XSS in `sw.js` HTML rewriter
`rewriteHtmlAttributeUrl()` returns a **decoded** URL (entities turned back into raw `&`, `"`, `<`, `>`), which was reinserted between the attribute quotes **without re-encoding**. A decoded value containing a quote could close the attribute early and inject HTML into the playground iframe.

**Fix:** `escapeHtml()` the rewritten value before interpolating it back into the attribute (same fix applied upstream in moodle-playground).

## Notes
- No committed SW bundle in this repo — the source `sw.js` is bundled at build time, so editing the source is sufficient.
- `node --check` passes on both files.
- A separate PR (#68) syncs the proxy worker; this PR is independent.