### PR TITLE
chore(dependabot): group @php-wasm/* updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Group all @php-wasm/* packages into a single PR. They are always
+    # released together with the same version, so separate PRs would race
+    # against each other and produce inconsistent lockfile states.
+    groups:
+      php-wasm:
+        patterns:
+          - "@php-wasm/*"
     labels:
       - "dependencies"
       - "npm"


### PR DESCRIPTION
## Problem

`@php-wasm/web` and `@php-wasm/universal` are always published together with the same version. With the current config Dependabot opens **one PR per package**, so they land at the same time, race against each other, and can leave `package-lock.json` in an inconsistent state.

## Fix

Use Dependabot's [`groups`](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) feature to collapse all `@php-wasm/*` bumps into a **single coherent PR**.

```yaml
groups:
  php-wasm:
    patterns:
      - "@php-wasm/*"
```

This mirrors the change applied in moodle-playground (ateeducacion/moodle-playground#116).