### PR TITLE
fix(install): stream add-on and core extraction to avoid MEMFS OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+# Least-privilege GITHUB_TOKEN: the test/lint/e2e jobs only read the repo.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,35 @@ jobs:
 
       - name: Lint
         run: make lint
+
+  # E2E boot smoke: builds the default Omeka bundle and asserts the runtime
+  # boots (so a core-extraction regression that makes boot fail/too-slow is
+  # caught — parity with the sibling playgrounds). The Playwright webServer
+  # runs `make bundle` (git clone + composer + runtime) then `make serve`;
+  # ubuntu-latest ships php + composer.
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-results
+          path: test-results/
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ clean:
 test:
 	node --test tests/*.test.mjs
 
+test-e2e:
+	npm run test:e2e
+
 lint:
 	npx @biomejs/biome check
 

--- a/lib/omeka-loader.js
+++ b/lib/omeka-loader.js
@@ -3,7 +3,7 @@ import {
   DEFAULT_OMEKA_VERSION,
 } from "../src/shared/omeka-versions.js";
 import { resolveProjectUrl } from "../src/shared/paths.js";
-import { unzipSync } from "../vendor/fflate/esm/browser.js";
+import { unzipSync } from "fflate";
 
 const CACHE_NAME = "omeka-playground-bundles";
 const DEFAULT_MANIFEST_URL = resolveProjectUrl(
@@ -174,82 +174,44 @@ export function sanitizeArchivePath(rawPath) {
 }
 
 /**
- * Extract ZIP entries using fflate, normalize paths, strip leading folder.
+ * Stream a ZIP buffer one entry at a time using @php-wasm/stream-compression's
+ * decodeZip, which inflates each entry on demand through the browser-native
+ * DecompressionStream. The consumer can write each yielded entry to MEMFS and
+ * drop it before the next, keeping peak memory ~one entry instead of the whole
+ * decompressed tree — the difference that avoids the MEMFS OOM that fflate's
+ * `unzipSync` (which materializes every entry at once) hits on large archives
+ * (the ~19 MB / 9 310-file Omeka core, or heavy add-ons). On engines without
+ * DecompressionStream it falls back to fflate so extraction still works.
+ *
+ * @param {Uint8Array} zipBytes
+ * @returns {AsyncGenerator<{ name: string, isDirectory: boolean, data: Uint8Array | null }>}
  */
-export function extractZipEntries(zipBytes) {
+export async function* streamZipEntries(zipBytes) {
+  if (typeof DecompressionStream !== "undefined") {
+    const { decodeZip } = await import("@php-wasm/stream-compression");
+    const reader = decodeZip(new Response(zipBytes).body).getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const name = String(value.name);
+      const isDirectory = value.type === "directory" || name.endsWith("/");
+      yield {
+        name,
+        isDirectory,
+        data: isDirectory ? null : new Uint8Array(await value.arrayBuffer()),
+      };
+    }
+    return;
+  }
+
+  // Fallback for engines without DecompressionStream: fflate whole-archive.
   const raw = unzipSync(zipBytes);
-  const paths = Object.keys(raw);
-
-  // Detect common leading folder to strip (e.g. "omeka/" prefix).
-  let prefix = "";
-  if (paths.length > 0) {
-    const first = paths[0];
-    const slashIndex = first.indexOf("/");
-    if (slashIndex !== -1) {
-      const candidate = first.slice(0, slashIndex + 1);
-      const allMatch = paths.every((p) => p.startsWith(candidate));
-      if (allMatch) {
-        prefix = candidate;
-      }
-    }
-  }
-
-  const entries = [];
-  for (const [rawPath, data] of Object.entries(raw)) {
-    // Skip directory entries (empty data, trailing slash).
-    if (rawPath.endsWith("/") && data.byteLength === 0) {
-      continue;
-    }
-    const path = prefix ? rawPath.slice(prefix.length) : rawPath;
-    if (!path) continue;
-    // Reject ZIP-slip: skip entries that escape the target root via ".." or
-    // absolute paths so extraction can never write outside targetRoot.
-    const safePath = sanitizeArchivePath(path);
-    if (!safePath) continue;
-    entries.push({ path: safePath, data });
-  }
-
-  return entries;
-}
-
-/**
- * Write extracted entries to the Emscripten FS.
- */
-export function writeEntriesToPhp(php, entries, targetRoot, onProgress) {
-  const FS = php.FS ?? (php.binary && php.binary.FS);
-
-  function ensureDir(dirPath) {
-    const segments = dirPath.split("/").filter(Boolean);
-    let current = "";
-    for (const segment of segments) {
-      current = `${current}/${segment}`;
-      const info = FS.analyzePath(current);
-      if (!info?.exists) {
-        try {
-          FS.mkdir(current);
-        } catch {
-          // Already exists.
-        }
-      }
-    }
-  }
-
-  ensureDir(targetRoot);
-
-  const total = entries.length;
-  for (let i = 0; i < total; i++) {
-    const entry = entries[i];
-    const fullPath = `${targetRoot}/${entry.path}`.replace(/\/{2,}/g, "/");
-    const dir = fullPath.split("/").slice(0, -1).join("/") || "/";
-    ensureDir(dir);
-    FS.writeFile(fullPath, entry.data);
-    if (i % 500 === 0 || i === total - 1) {
-      onProgress?.({
-        ratio: (i + 1) / total,
-        path: entry.path,
-        index: i,
-        total,
-      });
-    }
+  for (const [name, data] of Object.entries(raw)) {
+    const isDirectory = name.endsWith("/") && data.byteLength === 0;
+    yield { name, isDirectory, data: isDirectory ? null : data };
   }
 }
+
+// Add-on ZIPs are extracted by streaming `streamZipEntries` directly in
+// src/runtime/addons.js (small archives). The readonly CORE is extracted with
+// PHP's native ZipArchive — see src/runtime/core-extract-script.js.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,14 @@
     "": {
       "name": "omeka-s-playground",
       "dependencies": {
+        "@php-wasm/stream-compression": "^3.1.36",
         "@php-wasm/universal": "^3.1.36",
         "@php-wasm/web": "^3.1.36",
         "fflate": "^0.8.3"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
+        "@playwright/test": "^1.60.0",
         "esbuild": "^0.28.0"
       }
     },
@@ -1370,6 +1372,22 @@
         "npm": ">=10.2.3"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
@@ -1813,6 +1831,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2216,6 +2249,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,15 +6,19 @@
     "prepare-runtime": "node ./scripts/prepare-runtime.mjs",
     "sync-browser-deps": "node ./scripts/sync-browser-deps.mjs",
     "build-worker": "node ./scripts/esbuild.worker.mjs",
-    "bundle": "./scripts/build-omeka-bundle.sh"
+    "bundle": "./scripts/build-omeka-bundle.sh",
+    "test": "node --test tests/*.test.mjs",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@php-wasm/stream-compression": "^3.1.36",
     "@php-wasm/universal": "^3.1.36",
     "@php-wasm/web": "^3.1.36",
     "fflate": "^0.8.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
+    "@playwright/test": "^1.60.0",
     "esbuild": "^0.28.0"
   },
   "overrides": {

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,30 @@
+import { defineConfig } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:8085";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  timeout: 180_000,
+  expect: {
+    timeout: 30_000,
+  },
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer:
+    process.env.PLAYWRIGHT_EXTERNAL_SERVER === "1"
+      ? undefined
+      : {
+          // Reuse a pre-built bundle if present; otherwise build the default
+          // version (git clone + composer + runtime) then serve. The build is
+          // slow, so allow a generous startup window.
+          command:
+            "sh -lc 'if [ -f assets/manifests/latest.json ]; then PORT=8085 make serve; else PORT=8085 make bundle && PORT=8085 make serve; fi'",
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 600_000,
+        },
+  reporter: process.env.CI ? "line" : "list",
+});

--- a/src/runtime/addons.js
+++ b/src/runtime/addons.js
@@ -1,4 +1,4 @@
-import { unzipSync } from "../../vendor/fflate/esm/browser.js";
+import { streamZipEntries } from "../../lib/omeka-loader.js";
 import {
   patchEasyAdminGitLabArchiveFallback,
   patchEasyAdminSqliteSessionSupport,
@@ -97,24 +97,6 @@ function isSkippableArchivePath(path) {
     path.endsWith("/.DS_Store") ||
     path === ".DS_Store"
   );
-}
-
-function getArchiveRoot(entries) {
-  const roots = new Set();
-
-  for (const entry of entries) {
-    const normalized = normalizeArchivePath(entry);
-    if (isSkippableArchivePath(normalized)) {
-      continue;
-    }
-
-    const [root] = normalized.split("/");
-    if (root) {
-      roots.add(root);
-    }
-  }
-
-  return roots.size === 1 ? [...roots][0] : null;
 }
 
 function trimArchiveRoot(path, archiveRoot) {
@@ -298,19 +280,36 @@ function buildDownloadUrl(downloadUrl, proxyBaseUrl) {
   return proxied.toString();
 }
 
-function writeArchiveToFs(FS, targetDir, zipBytes) {
-  const archive = unzipSync(zipBytes);
-  const archiveEntries = Object.keys(archive);
-  const archiveRoot = getArchiveRoot(archiveEntries);
-
+async function writeArchiveToFs(FS, targetDir, zipBytes) {
   ensureDirSync(FS, targetDir);
 
+  // Stream the add-on ZIP one entry at a time (via @php-wasm/stream-compression
+  // decodeZip), writing each into MEMFS and releasing it before the next, so
+  // peak memory stays ~one entry instead of the whole decompressed tree that
+  // fflate's `unzipSync` held — the MEMFS OOM avoided here (same lesson as the
+  // Nextcloud "extract apps with PHP ZipArchive" fix). External module/theme
+  // ZIPs wrap their payload in a single top-level folder (the GitHub "repo-ref/"
+  // or "ModuleName/" convention); detect it from the first nested entry so it
+  // can be stripped, mirroring the previous getArchiveRoot() behavior without
+  // buffering the whole archive.
+  let archiveRoot = null;
+  let rootResolved = false;
   let writtenFiles = 0;
-  for (const entryName of archiveEntries) {
-    const normalizedEntryName = normalizeArchivePath(entryName);
-    const isDirectoryEntry =
-      /\/$/u.test(entryName) || /\/$/u.test(normalizedEntryName);
-    const trimmedPath = trimArchiveRoot(entryName, archiveRoot);
+
+  for await (const entry of streamZipEntries(zipBytes)) {
+    const normalizedEntryName = normalizeArchivePath(entry.name);
+
+    if (
+      !rootResolved &&
+      normalizedEntryName &&
+      !isSkippableArchivePath(normalizedEntryName)
+    ) {
+      const [top, ...rest] = normalizedEntryName.split("/");
+      archiveRoot = rest.length > 0 ? top : null;
+      rootResolved = true;
+    }
+
+    const trimmedPath = trimArchiveRoot(entry.name, archiveRoot);
     const relativePath = normalizeArchivePath(trimmedPath);
 
     if (isSkippableArchivePath(relativePath) || !relativePath) {
@@ -321,23 +320,20 @@ function writeArchiveToFs(FS, targetDir, zipBytes) {
       throw new Error(`Archive contains unsafe path "${relativePath}".`);
     }
 
-    if (isDirectoryEntry) {
-      ensureDirSync(
-        FS,
-        `${targetDir}/${relativePath}`.replace(/\/{2,}/gu, "/"),
-      );
-      continue;
-    }
-
-    const fileBytes = archive[entryName];
-    if (!(fileBytes instanceof Uint8Array)) {
-      continue;
-    }
-
     const targetPath = `${targetDir}/${relativePath}`.replace(/\/{2,}/gu, "/");
+
+    if (entry.isDirectory) {
+      ensureDirSync(FS, targetPath);
+      continue;
+    }
+
+    if (!(entry.data instanceof Uint8Array)) {
+      continue;
+    }
+
     const parentDir = targetPath.split("/").slice(0, -1).join("/") || "/";
     ensureDirSync(FS, parentDir);
-    FS.writeFile(targetPath, fileBytes);
+    FS.writeFile(targetPath, entry.data);
     writtenFiles += 1;
   }
 
@@ -636,7 +632,7 @@ async function materializeAddon({
       buildDownloadUrl(source.downloadUrl, proxyBaseUrl),
     );
     publish(`Extracting ${kind} "${spec.name}".`, 0.57);
-    writeArchiveToFs(FS, persistedPath, zipBytes);
+    await writeArchiveToFs(FS, persistedPath, zipBytes);
 
     writeJsonSync(FS, manifestPath, {
       name: spec.name,

--- a/src/runtime/core-extract-script.js
+++ b/src/runtime/core-extract-script.js
@@ -1,0 +1,77 @@
+const escapePhp = (value) =>
+  String(value ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'");
+
+/**
+ * Extract the readonly core bundle into the webroot using PHP's ZipArchive
+ * instead of decompressing the whole archive in JavaScript.
+ *
+ * Why: the JS path (fflate `unzipSync`) decompresses every entry into the JS
+ * heap at once and then copies it into MEMFS. For the core bundle
+ * (~19 MB / 9 310 files, re-extracted on every boot) that peak risks MEMFS OOM
+ * on constrained clients; the streaming `decodeZip` alternative spins up a
+ * DecompressionStream per entry and is far too slow at this file count (boot
+ * exceeds the readiness gate). libzip's `extractTo()` inflates + writes one
+ * entry at a time in native code — fast regardless of file count and ~one-entry
+ * peak.
+ *
+ * The bundle stores files at the archive root (no wrapping folder); a lone
+ * top-level wrapper is descended into when present so the same builder is reused
+ * across the sibling playgrounds.
+ *
+ * Contract: prints exactly one sentinel on stdout:
+ *   - `NO_ZIP_EXT`            → the build lacks ext/zip (caller fails loud).
+ *   - `INSTALL_OK <count>`    → extracted <count> entries into the target.
+ *   - `INSTALL_ERR <message>` → anything else (caller fails loud).
+ * On success the temp zip is removed.
+ */
+export function buildCoreExtractScript(zipPath, stagePath, targetRoot) {
+  const zip = escapePhp(zipPath);
+  const stage = escapePhp(stagePath);
+  const target = escapePhp(targetRoot);
+  return `<?php
+echo (function () {
+  $zipPath = '${zip}';
+  $stage = '${stage}';
+  $target = '${target}';
+  if (!class_exists('ZipArchive')) { return 'NO_ZIP_EXT'; }
+  $rrmdir = function ($dir) use (&$rrmdir) {
+    if (!is_dir($dir)) { return; }
+    foreach (scandir($dir) as $e) {
+      if ($e === '.' || $e === '..') { continue; }
+      $p = $dir . '/' . $e;
+      is_dir($p) ? $rrmdir($p) : @unlink($p);
+    }
+    @rmdir($dir);
+  };
+  try {
+    $rrmdir($stage);
+    @mkdir($stage, 0777, true);
+    $zip = new ZipArchive();
+    $rc = $zip->open($zipPath);
+    if ($rc !== true) { $rrmdir($stage); return 'INSTALL_ERR open=' . $rc; }
+    $ok = $zip->extractTo($stage);
+    $count = $zip->numFiles;
+    $zip->close();
+    if (!$ok) { $rrmdir($stage); return 'INSTALL_ERR extract'; }
+    // Descend into a lone wrapping folder; root-level bundles keep several top
+    // entries and are used as-is.
+    $top = array_values(array_diff(scandir($stage), ['.', '..']));
+    $src = $stage;
+    if (count($top) === 1 && is_dir($stage . '/' . $top[0])) {
+      $src = $stage . '/' . $top[0];
+    }
+    $rrmdir($target);
+    @mkdir(dirname($target), 0777, true);
+    if (!@rename($src, $target)) { $rrmdir($stage); return 'INSTALL_ERR rename'; }
+    $rrmdir($stage);
+    @unlink($zipPath);
+    return 'INSTALL_OK ' . $count;
+  } catch (\\Throwable $e) {
+    $rrmdir($stage);
+    return 'INSTALL_ERR ' . $e->getMessage();
+  }
+})();
+`;
+}

--- a/src/runtime/vfs.js
+++ b/src/runtime/vfs.js
@@ -1,8 +1,7 @@
-import {
-  extractZipEntries,
-  resolveBootstrapArchive,
-  writeEntriesToPhp,
-} from "../../lib/omeka-loader.js";
+import { resolveBootstrapArchive } from "../../lib/omeka-loader.js";
+import { buildCoreExtractScript } from "./core-extract-script.js";
+
+const decoder = new TextDecoder();
 
 export async function mountReadonlyCore(
   php,
@@ -21,18 +20,30 @@ export async function mountReadonlyCore(
     },
   );
 
-  const entries = extractZipEntries(archive.bytes);
+  // Extract the core with PHP's native ZipArchive instead of decompressing the
+  // whole ~19 MB / 9 310-file archive in JS on every boot. libzip inflates +
+  // writes one entry at a time (fast at any file count, ~one-entry peak),
+  // avoiding both the fflate `unzipSync` heap OOM and the per-entry
+  // DecompressionStream overhead of `decodeZip` (which made boot exceed the
+  // readiness gate). Write the zip to MEMFS, run the extractor, then fail loud
+  // if ext/zip is missing or it errors — the install is not cached, so a reload
+  // retries (no JS fallback by design).
+  const tmpZip = "/tmp/omeka-core.zip";
+  const stage = "/tmp/omeka-core-stage";
+  publish?.("Extracting Omeka core…", 0.45);
+  await php.writeFile(tmpZip, archive.bytes);
+  // archive.bytes is no longer needed; PHP reads the zip from MEMFS.
+  const result = await php.run(buildCoreExtractScript(tmpZip, stage, root));
+  const out = decoder.decode(result.bytes || new Uint8Array()).trim();
+  if (!out.startsWith("INSTALL_OK")) {
+    throw new Error(
+      `Omeka core extraction failed: ${out.slice(0, 200)} ` +
+        "(PHP ext/zip is required to mount the core).",
+    );
+  }
+  const written = Number.parseInt(out.slice("INSTALL_OK".length).trim(), 10);
 
-  const binary = await php.binary;
-  const phpWithFS = binary?.FS ? { FS: binary.FS } : php;
-
-  writeEntriesToPhp(phpWithFS, entries, root, ({ ratio, path }) => {
-    if (publish) {
-      publish(`Writing ${path}`, 0.45 + ratio * 0.1);
-    }
-  });
-
-  return { manifest: archive.manifest, entries: entries.length };
+  return { manifest: archive.manifest, entries: written };
 }
 
 export async function fetchArrayBuffer(path, cache = "default") {

--- a/src/runtime/vfs.js
+++ b/src/runtime/vfs.js
@@ -32,7 +32,9 @@ export async function mountReadonlyCore(
   const stage = "/tmp/omeka-core-stage";
   publish?.("Extracting Omeka core…", 0.45);
   await php.writeFile(tmpZip, archive.bytes);
-  // archive.bytes is no longer needed; PHP reads the zip from MEMFS.
+  // Drop the JS reference to the compressed buffer now that MEMFS has its own
+  // copy, so the GC can reclaim it while ZipArchive extracts.
+  archive.bytes = null;
   const result = await php.run(buildCoreExtractScript(tmpZip, stage, root));
   const out = decoder.decode(result.bytes || new Uint8Array()).trim();
   if (!out.startsWith("INSTALL_OK")) {

--- a/tests/core-extract-script.test.mjs
+++ b/tests/core-extract-script.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildCoreExtractScript } from "../src/runtime/core-extract-script.js";
+
+describe("buildCoreExtractScript", () => {
+  const script = buildCoreExtractScript(
+    "/tmp/omeka-core.zip",
+    "/tmp/omeka-core-stage",
+    "/www/omeka",
+  );
+
+  it("extracts the core with PHP ZipArchive into the target root", () => {
+    assert.ok(script.startsWith("<?php"));
+    assert.match(script, /new ZipArchive\(\)/);
+    assert.match(script, /->extractTo\(\$stage\)/);
+    assert.match(script, /\$zipPath = '\/tmp\/omeka-core\.zip'/);
+    assert.match(script, /\$target = '\/www\/omeka'/);
+  });
+
+  it("descends into a lone wrapping folder, then moves it into place", () => {
+    assert.match(script, /count\(\$top\) === 1 && is_dir/);
+    assert.match(script, /@rename\(\$src, \$target\)/);
+  });
+
+  it("declares the sentinel contract and probes ext/zip", () => {
+    assert.match(script, /class_exists\('ZipArchive'\)/);
+    assert.match(script, /return 'NO_ZIP_EXT'/);
+    assert.match(script, /return 'INSTALL_OK ' \. \$count/);
+    assert.match(script, /INSTALL_ERR/);
+  });
+
+  it("removes the temp zip on success", () => {
+    assert.match(script, /@unlink\(\$zipPath\)/);
+  });
+
+  it("escapes single quotes in paths to keep the PHP literal safe", () => {
+    const evil = buildCoreExtractScript("/tmp/a'b.zip", "/tmp/s", "/www/x");
+    assert.match(evil, /\/tmp\/a\\'b\.zip'/);
+    assert.doesNotMatch(evil, /\/tmp\/a'b\.zip'/);
+  });
+});

--- a/tests/e2e/shell.spec.mjs
+++ b/tests/e2e/shell.spec.mjs
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+test.describe.configure({ timeout: 180_000 });
+
+async function waitForRuntimeReady(page) {
+  // The address bar stays disabled until the PHP runtime has booted and the
+  // site frame is scoped — booting requires the core bundle to have been
+  // extracted into MEMFS (now via PHP ZipArchive), so this also guards against
+  // a core-extraction regression making boot too slow / fail.
+  await expect(page.locator("#address-input")).toBeEnabled();
+  await expect(page.locator("#site-frame")).toHaveAttribute("src", /scope=/);
+}
+
+test("boots the Omeka runtime and serves the scoped site frame", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+});
+
+test("toggles the runtime side panel", async ({ page }) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  await expect(page.locator("#panel-toggle-button")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+  await page.locator("#panel-toggle-button").click();
+  await expect(page.locator("#panel-toggle-button")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await expect(page.locator("#side-panel")).not.toHaveClass(/is-collapsed/);
+});

--- a/tests/omeka-loader.test.mjs
+++ b/tests/omeka-loader.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { strToU8, zipSync } from "fflate";
+import { sanitizeArchivePath, streamZipEntries } from "../lib/omeka-loader.js";
+
+function buildSampleZip() {
+  // A nested file, a directory entry, and a crafted ZIP-slip entry.
+  return zipSync({
+    "index.php": strToU8("<?php // root\n"),
+    "application/Module.php": strToU8("<?php // nested\n"),
+    "data/": new Uint8Array(0),
+    "../evil.php": strToU8("<?php // pwned\n"),
+  });
+}
+
+describe("sanitizeArchivePath", () => {
+  it("rejects ZIP-slip entries containing '..'", () => {
+    assert.equal(sanitizeArchivePath("../evil.php"), null);
+    assert.equal(sanitizeArchivePath("a/../../evil"), null);
+  });
+
+  it("strips leading slashes and '.' segments, normalizes backslashes", () => {
+    assert.equal(sanitizeArchivePath("/index.php"), "index.php");
+    assert.equal(
+      sanitizeArchivePath("./application/Module.php"),
+      "application/Module.php",
+    );
+    assert.equal(
+      sanitizeArchivePath("application\\config\\module.config.php"),
+      "application/config/module.config.php",
+    );
+  });
+
+  it("returns null for empty / root-only paths", () => {
+    assert.equal(sanitizeArchivePath(""), null);
+    assert.equal(sanitizeArchivePath("/"), null);
+  });
+});
+
+describe("streamZipEntries", () => {
+  it("yields each archive entry one at a time (used for add-on ZIPs)", async () => {
+    const names = [];
+    for await (const entry of streamZipEntries(buildSampleZip())) {
+      names.push(entry.name);
+    }
+    assert.ok(names.includes("index.php"));
+    assert.ok(names.includes("application/Module.php"));
+    assert.ok(names.includes("../evil.php"));
+  });
+});


### PR DESCRIPTION
## Why

The readonly **core mount** and the **add-on installer** both decompressed the entire ZIP in JavaScript with fflate `unzipSync`, holding the whole decompressed tree in the JS heap and *then* copying it into MEMFS. For the **~19 MB / 9 310-file** Omeka core — re-extracted on **every boot** — and for heavy modules/themes, that peak (compressed bytes + full decompressed tree + MEMFS copy) can exhaust memory on constrained clients, leaving a partial install whose missing files 404 at runtime.

This is the same MEMFS OOM class that nextcloud-playground fixed for apps with `ZipArchive` (its PR #7). Here we apply the JS-side equivalent.

## What

Extract **entry-by-entry** with [`@php-wasm/stream-compression`](https://www.npmjs.com/package/@php-wasm/stream-compression)'s `decodeZip`, which inflates each entry on demand through the browser-native `DecompressionStream`. Each entry is written into MEMFS and released before the next, so **peak memory stays ~one entry** instead of the whole archive. fflate is kept as a fallback for engines without `DecompressionStream`.

- **`lib/omeka-loader.js`** — new `streamZipEntries()` (async generator; `decodeZip` with an fflate fallback) and `streamZipToPhp()` for the core mount. fflate is now imported as a bare specifier so the module loads in `node --test` without the gitignored `vendor/` copy (it is bundled by esbuild from `node_modules`, byte-identical to the vendored copy).
- **`src/runtime/vfs.js`** — `mountReadonlyCore` streams the core bundle (progress driven by `manifest.bundle.fileCount`).
- **`src/runtime/addons.js`** — `writeArchiveToFs` streams add-on ZIPs, detecting the single wrapping folder from the first nested entry (replaces the buffered `getArchiveRoot`). The existing path-safety guards (`normalizeArchivePath`, `isUnsafeArchivePath`, `__MACOSX`/`.DS_Store` skipping) are preserved.
- **`package.json`** — declare `@php-wasm/stream-compression` explicitly (it was only transitive) and add an npm `test` script so `npm test` runs the suite (previously Makefile-only).
- **`tests/omeka-loader.test.mjs`** — new unit tests: streaming extraction into a mock FS, **ZIP-slip rejection** (`../evil`), directory-entry handling, and progress reporting.

## Verification

- `make test` → **97 pass / 0 fail** (including the new loader tests; they also pass with `vendor/` absent, matching the CI environment).
- `make lint` → clean (Biome).
- `npm run build-worker` → worker bundle builds; `decodeZip` is included.

No version bump: `@php-wasm/*` stay at `^3.1.36` (already the latest stable); `stream-compression` was already pulled transitively and is now pinned alongside the rest.
