### PR TITLE
build(php-wasm): bundle only the offered PHP runtime versions

### DIFF
--- a/scripts/esbuild.worker.mjs
+++ b/scripts/esbuild.worker.mjs
@@ -1,10 +1,65 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
 const require = createRequire(import.meta.url);
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoDir = resolvePath(scriptDir, "..");
+
+// Only bundle the PHP runtime versions this playground actually offers. The
+// monolithic @php-wasm/web's loadWebRuntime() switch dynamically imports every
+// @php-wasm/web-X-Y package, so esbuild can't tree-shake and would emit all 8
+// versions' .wasm (~798 MB) into dist/ — even though the browser only ever
+// downloads the one version a session selects. Stub the non-offered version
+// packages so their assets are never emitted (a deploy/CI/disk reduction;
+// runtime behavior for the offered versions is unchanged).
+const ALL_PHP_VERSIONS = [
+  "5-2",
+  "7-4",
+  "8-0",
+  "8-1",
+  "8-2",
+  "8-3",
+  "8-4",
+  "8-5",
+];
+const offeredPhp = [
+  ...new Set(
+    (
+      JSON.parse(
+        readFileSync(resolvePath(repoDir, "playground.config.json"), "utf8"),
+      ).runtimes || []
+    )
+      .map((r) => r.phpVersion)
+      .filter(Boolean),
+  ),
+];
+const keepVersions = offeredPhp.map((v) => v.replace(".", "-"));
+const dropVersions = ALL_PHP_VERSIONS.filter((v) => !keepVersions.includes(v));
+
+const stripUnusedPhpVersions = {
+  name: "strip-unused-php-versions",
+  setup(api) {
+    if (dropVersions.length === 0) return;
+    const filter = new RegExp(
+      `@php-wasm/(?:web|node)-(?:${dropVersions.join("|")})(?:/|$)`,
+    );
+    api.onResolve({ filter }, (args) => ({
+      path: args.path,
+      namespace: "phpver-stub",
+    }));
+    api.onLoad({ filter: /.*/, namespace: "phpver-stub" }, (args) => ({
+      loader: "js",
+      contents:
+        `export function getPHPLoaderModule(){throw new Error("PHP runtime not bundled in this build: ${args.path}");}\n` +
+        `export function getIntlExtensionPath(){throw new Error("PHP intl not bundled in this build: ${args.path}");}\n`,
+    }));
+  },
+};
 
 // @php-wasm/web >= 3.1.22 references "../intl/shared/icu.dat", expecting a
 // sibling @php-wasm/intl package that is never published to npm. The file still
@@ -32,7 +87,7 @@ await build({
   banner: {
     js: `const __APP_ROOT__ = new URL("../", import.meta.url).href;`,
   },
-  plugins: [icuDatShim],
+  plugins: [icuDatShim, stripUnusedPhpVersions],
   loader: {
     ".wasm": "file",
     ".so": "file",
@@ -64,4 +119,6 @@ await build({
   },
 });
 
-console.log("Built dist/php-worker.bundle.js");
+console.log(
+  `Built dist/php-worker.bundle.js (bundled PHP runtimes: ${keepVersions.join(", ") || "none"})`,
+);


### PR DESCRIPTION
## Why
The worker bundle shipped **every** PHP version's runtime into `dist/` — **42 `.wasm`, ~798 MB** — because `@php-wasm/web`'s `loadWebRuntime()` selects the version at runtime (a `switch` that `await import()`s all `@php-wasm/web-X-Y` packages), so esbuild can't tree-shake. Omeka only offers **PHP 8.3**, so the other seven versions were built and deployed to GitHub Pages but **never downloaded** (the browser only fetches the one version a session selects).

## What
An esbuild plugin (`scripts/esbuild.worker.mjs`) stubs the `@php-wasm/web-X-Y` / `node-X-Y` packages for versions **not** in `playground.config.json`, so their `.wasm`/`.so` are never emitted. The keep-set is derived from the config (can't drift from the UI); `loadWebRuntime` behavior for the offered version is unchanged.

## Result
`dist/*.wasm`: **798 MB → 40 MB** (42 → 2 files: `php_8_3` jspi + asyncify only).

This is a **deploy-artifact / CI / disk** reduction — smaller, faster GitHub-Pages deploys and CI, headroom under the Pages ~1 GB limit. It does **not** change the user's cold load (the browser already downloaded only the selected version).

## Verification
- `make test` → 99 pass; `make lint` clean.
- `npm run build-worker` → `dist` contains only `php_8_3.*`.
- e2e (CI) boots Omeka on PHP 8.3 — confirms the offered runtime is still bundled.
