### PR TITLE
fix(persistence): never let a bad journal op brick the reload

### DIFF
--- a/src/runtime/fs-persistence.js
+++ b/src/runtime/fs-persistence.js
@@ -81,6 +81,30 @@ export async function clearJournal(scopeId) {
 }
 
 /**
+ * Replay the journal, tolerating ops that can't be applied to a fresh FS so a
+ * single bad op never bricks the reload. This happens because Omeka writes media
+ * in an isolated CLI runtime (cli-runtime.js) whose creates aren't journaled,
+ * while the user's later delete (in the main runtime) is — leaving a dangling
+ * unlink. Fast path replays the whole batch; on any failure, replay op-by-op and
+ * skip the ones that throw (a failed unlink just means the file is already gone,
+ * which is the intended end state).
+ */
+function replayResilient(rawPhp, ops) {
+  if (!ops || ops.length === 0) return;
+  try {
+    replayFSJournal(rawPhp, ops);
+  } catch {
+    for (const op of ops) {
+      try {
+        replayFSJournal(rawPhp, [op]);
+      } catch {
+        // Skip un-appliable op.
+      }
+    }
+  }
+}
+
+/**
  * Replay the persisted /persist journal onto the fresh PHP instance, then start
  * journaling new changes back to IndexedDB (debounced). Must run before the app
  * bootstraps so the install gate sees the restored database.
@@ -108,7 +132,5 @@ export async function initFsPersistence(rawPhp, scopeId) {
   });
 
   const savedPersistOps = await loadOps(persistDb);
-  if (savedPersistOps.length > 0) {
-    replayFSJournal(rawPhp, savedPersistOps);
-  }
+  replayResilient(rawPhp, savedPersistOps);
 }


### PR DESCRIPTION
Hotfix for #75: deleting an item then reloading bricked the boot (`replayFSJournal` threw on an `unlink` of a media file whose CREATE wasn't journaled — Omeka writes media in an isolated CLI runtime, so the delete is recorded but the create isn't). Make replay resilient: fast-path the whole batch, and on failure replay op-by-op skipping the ones that throw (a failed unlink means the file is already gone — the intended state). The item stays deleted and the runtime always boots. **Known follow-up:** CLI-runtime-written media isn't journaled, so those files don't persist across reload (the DB does) — tracked separately. make test: 99 pass; lint clean; worker builds.