### PR TITLE
fix(persistence): seed blueprint content only once so deletions stick

### DIFF
--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -19,6 +19,13 @@ export const OMEKA_ROOT = "/www/omeka";
 export const OMEKA_FILES_PATH = "/persist/mutable/files";
 export const PLAYGROUND_BLUEPRINT_MEDIA_PATH =
   "/persist/runtime/blueprint-media";
+// Marker recording that the blueprint's *content* (items + itemSets) has already
+// been seeded for the current bundle/blueprint manifest. Lives under /persist so
+// it is journaled and survives reloads. Its presence makes the install script seed
+// content only once, so a user who deletes/edits a seeded item keeps that change
+// across reloads (a manifest change or ?clean=1/reset clears it → reseed).
+export const PLAYGROUND_CONTENT_MARKER_PATH =
+  "/persist/runtime/content-seeded.json";
 
 function phpString(value) {
   return String(value).replaceAll("\\", "\\\\").replaceAll("'", "\\'");
@@ -394,6 +401,20 @@ $state = [
 ];
 
 $warnings = [];
+// Seed blueprint content (items + itemSets) only once per manifest. After the
+// first successful provisioning we drop a marker keyed by the bundle manifest, so
+// on later reloads the content loops are skipped — a user who deleted or edited a
+// seeded item keeps that change. A manifest change (new signature) or a reset
+// (?clean=1 wipes /persist, removing the marker) reseeds.
+$contentMarkerPath = '${PLAYGROUND_CONTENT_MARKER_PATH}';
+$contentSignature = '${phpString(JSON.stringify(manifestState))}';
+$shouldSeedContent = true;
+if (is_file($contentMarkerPath)) {
+  $previousSignature = @file_get_contents($contentMarkerPath);
+  if ($previousSignature !== false && $previousSignature === $contentSignature) {
+    $shouldSeedContent = false;
+  }
+}
 $shouldRerunBootstrap = false;
 $themeSpecsByName = [];
 foreach (($blueprint['themes'] ?? []) as $themeSpec) {
@@ -786,7 +807,7 @@ $debug(sprintf(
 ));
 
 $itemSetIdsByTitle = [];
-if ($titlePropertyId) {
+if ($titlePropertyId && $shouldSeedContent) {
 foreach (($blueprint['itemSets'] ?? []) as $itemSetSpec) {
   if (empty($itemSetSpec['title'])) {
     continue;
@@ -934,10 +955,14 @@ foreach (($blueprint['items'] ?? []) as $itemSpec) {
     $warnings[] = sprintf('Unable to provision item "%s": %s', $itemSpec['title'], $describeThrowable($e));
   }
 }
-} elseif (($blueprint['itemSets'] ?? []) || ($blueprint['items'] ?? [])) {
+} elseif ($shouldSeedContent && (($blueprint['itemSets'] ?? []) || ($blueprint['items'] ?? []))) {
   $warnings[] = 'Blueprint content provisioning was skipped because dcterms:title is not available in this runtime.';
 }
 
+if ($shouldSeedContent) {
+  @mkdir(dirname($contentMarkerPath), 0777, true);
+  @file_put_contents($contentMarkerPath, $contentSignature);
+}
 file_put_contents($statePath, json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 echo "omeka-playground-bootstrap-complete\\n";
 foreach ($warnings as $warning) {


### PR DESCRIPTION
## Problem (reported in prod)

After Wave 4 (within-session persistence), a user who **deletes a seed/blueprint item** sees it **reappear after reload**; an **edited** seed item is **reverted** to blueprint values. User-*created* items persist correctly.

## Root cause — not a persistence bug

`playground-install.php` (built by `bootstrap.js buildInstallScript`) runs on **every boot**. Only the *core* install is gated by `$status->isInstalled()`; the **blueprint content provisioning** (items `bootstrap.js:825`, itemSets `:790`) ran **ungated** every boot and is idempotent-by-title — a missing blueprint item is re-`create`d, an existing one is `update`d (overwriting edits). Before Wave 4 the whole DB reset each reload so this was invisible; now that user content persists, the re-seeding makes deletions/edits of seed content silently revert.

## Fix — seed content once per manifest

- After the first successful provisioning, drop a marker `/persist/runtime/content-seeded.json` keyed by the **bundle manifest signature**.
- On later boots with the same signature, **skip** the items + itemSets loops → user deletions/edits of seed content **stick**.
- A **manifest change** (new signature) or a **reset** (`?clean=1` wipes `/persist`, removing the marker) **reseeds**.
- The marker lives under `/persist` so it is journaled and survives reloads; it is only written on the final (`bootstrap-complete`) pass, never on a `bootstrap-continue` rerun.
- Structural provisioning (modules, themes, sites, users) is **unchanged** — only content is gated.

## Verification

- `make lint` ✅ · `make test` ✅ (unchanged suite) · `make bundle` ✅
- Manual matrix to confirm on the preview: create item → reload → persists; delete seed item → reload → stays gone; `?clean=1` → seed content back.