### PR TITLE
docs: restore AGENTS.md and add a debugging section (manual + e2e)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,299 +1,505 @@
 <!--
 MAINTENANCE: Update this file when:
-- Adding/removing npm scripts in package.json or targets in the Makefile
+- Adding/removing npm scripts in package.json or targets in Makefile
 - Changing the runtime flow (shell, remote host, service worker, php worker, dev proxy server)
-- Changing the persistence model (paths under /persist, the IndexedDB journal, the seed marker)
 - Modifying the Omeka bundle format, manifest schema, or storage model
-- Changing the scoped URL routing scheme or the GitHub Pages base path
-- Changing CI (workflows, test commands, vendored vs. bare-specifier deps)
+- Changing deployment assumptions for GitHub Pages or other static hosting
+- Adding new conventions for blueprints, autologin, or persistent state
 -->
 
 # AGENTS.md
 
-Debugging and development guide for the **Omeka S Playground** — a full Omeka S
-instance that runs entirely in the browser on PHP-WASM. This file is written for
-AI agents and humans doing day-to-day work on the playground. It is one of four
-sibling PHP-WASM playgrounds (Nextcloud, Moodle, Omeka, FacturaScripts) that
-share the same architecture; details below are verified against *this* repo.
+This file provides guidance to AI coding agents when working with code in this repository.
 
-## Overview / Architecture
+## Project Overview
 
-The browser app is layered:
+Omeka S Playground runs a full Omeka S instance entirely in the browser using WebAssembly.
+It is inspired by WordPress Playground, but this repository is a much smaller static-site
+application rather than a monorepo.
+
+The project has five main layers:
+
+1. Shell UI: `index.html` and `src/shell/main.js`
+2. Runtime host: `remote.html` and `src/remote/main.js`
+3. Request routing: `sw.js` and `php-worker.js`
+4. PHP/Omeka runtime: `src/runtime/*` + generated assets under `assets/omeka/`
+5. Local dev proxy server: `scripts/dev-server.mjs`
+
+At runtime, the readonly Omeka core is loaded from a prebuilt bundle into memory, while
+mutable state is stored separately in browser persistence.
+
+## Build System
+
+This project uses a small npm + Makefile workflow.
+
+### Requirements
+
+- Node.js 18+
+- npm
+- Composer
+- Git
+
+### Common Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Prepare browser-side runtime assets
+npm run sync-browser-deps
+npm run prepare-runtime
+
+# Build the Omeka bundle
+npm run bundle
+
+# End-to-end local workflow
+make up
+
+# Individual Make targets
+make deps
+make prepare
+make bundle
+make serve
+make lint
+make format
+make test
+make clean
+make reset
+```
+
+### Important Scripts
+
+- `npm run sync-browser-deps`: vendors browser runtime dependencies (fflate)
+- `npm run prepare-runtime`: prepares the PHP runtime assets
+- `npm run build-worker`: bundles php-worker.js via esbuild into `dist/php-worker.bundle.js`
+- `npm run bundle`: fetches/builds Omeka for a single version (selected via the `OMEKA_VERSION` env var) and generates the readonly bundle + per-version manifest
+- `make bundle-all`: builds bundles for every supported Omeka version
+- `make serve`: runs the local Node dev server, including the addon proxy endpoint for remote blueprint ZIP downloads
+
+### Supported Omeka versions
+
+Supported versions are declared in `src/shared/omeka-versions.js` and consumed by:
+
+- the build scripts (to select the git branch or release ZIP to fetch)
+- the browser runtime (to pick the correct manifest URL at boot)
+- the shell UI (to render the version dropdown in Settings)
+
+Add a new version by appending an entry to `OMEKA_VERSIONS` (with a `source.type` of either `git` or `release-zip`) and adding a matching target in the `Makefile`.
+
+### Generated Assets
+
+- `assets/omeka/<version>/`: readonly runtime bundle files (`.zip`), one directory per supported Omeka version (e.g. `4.1.1`, `4.2.0`).
+- `assets/manifests/<version>.json`: generated bundle manifest per Omeka version. `latest.json` is written for the default version as a backward-compat alias.
+- `dist/`: esbuild-bundled worker and `@php-wasm` WASM binaries
+
+Do not hand-edit generated bundle artifacts unless the task is specifically about the build output.
+
+## Architecture
+
+### Runtime Flow
+
+The browser application is structured like this:
 
 ```text
-index.html              shell UI (toolbar, address bar, #site-frame, settings)
-  └─ src/shell/main.js
-       └─ remote.html    runtime host page (registers SW, hosts the scoped iframe)
-            └─ src/remote/main.js
-                 └─ sw.js                 service worker: intercepts same-origin
-                      └─ php-worker.js     the worker — owns the PHP instance
-                           ├─ src/runtime/*   php-loader, php-compat, bootstrap,
-                           │                   vfs, fs-persistence, crash-recovery,
-                           │                   addons, manifest, cli-runtime …
-                           ├─ src/shared/*    config, blueprint, paths, protocol,
-                           │                   omeka-versions, storage …
-                           └─ lib/omeka-loader.js   manifest + bundle fetch/unzip
+index.html
+  -> src/shell/main.js
+     -> remote.html
+        -> src/remote/main.js
+           -> sw.js
+              -> php-worker.js (bundled via esbuild into dist/)
+                 -> src/runtime/php-loader.js (@php-wasm/web)
+                 -> src/runtime/php-compat.js (API wrapper)
+                 -> src/runtime/bootstrap.js
+                 -> src/runtime/vfs.js
+                 -> src/runtime/crash-recovery.js
 ```
 
-Key facts:
+Responsibilities:
 
-- **Blueprint-driven provisioning.** A JSON blueprint (default
-  `assets/blueprints/default.blueprint.json`, overridable via `?blueprint=`,
-  `?blueprint-url=`, or base64url `?blueprint-data=`) describes the desired
-  state: users, sites, items, item sets, media, modules, themes. `bootstrap.js`
-  generates a PHP install script from it.
-- **esbuild-bundled worker.** `php-worker.js` is bundled to
-  `dist/php-worker.bundle.js` by `scripts/esbuild.worker.mjs`. The `@php-wasm`
-  WASM binaries and ICU data are emitted into `dist/` too.
-- **Readonly core + mutable overlay.** The Omeka core is mounted readonly into
-  the WASM FS under `/www/omeka` from a prebuilt ZIP bundle; all mutable state
-  lives under `/persist` and is journaled to IndexedDB (see Persistence model).
-- **`@php-wasm/*` pinned at `^3.1.36`** in `package.json` (`@php-wasm/web`,
-  `@php-wasm/universal`, `@php-wasm/fs-journal`, `@php-wasm/stream-compression`),
-  plus `fflate ^0.8.3`. Lint is **Biome** (`biome.json`). Common targets:
-  `make test` / `make lint` / `make bundle`.
+- `index.html` / `src/shell/main.js`
+  - Toolbar, URL bar, iframe host, blueprint import, runtime status
+- `remote.html` / `src/remote/main.js`
+  - Registers the service worker and hosts the scoped playground iframe
+- `sw.js`
+  - Intercepts same-origin requests
+  - Maps unscoped/static vs scoped/runtime requests
+  - Rewrites redirects and HTML links for GitHub Pages subpaths
+- `php-worker.js`
+  - Owns the `@php-wasm` PHP instance for a scope
+  - Boots Omeka and serves HTTP requests through the bridge
+  - Applies the outbound HTTP policy
+  - Handles crash recovery and runtime rotation
+- `src/runtime/php-loader.js`
+  - Creates the PHP runtime via `@php-wasm/web` loadWebRuntime
+  - Deferred initialization pattern (call refresh() before use)
+- `src/runtime/php-compat.js`
+  - Wraps the raw `@php-wasm` PHP instance with the API expected by bootstrap/addons
+  - Handles request/response conversion, cookie jar, static file serving
+- `src/runtime/crash-recovery.js`
+  - Detects fatal WASM errors (memory access, unreachable, resource exhaustion)
+  - Snapshots DB/addon files before runtime destruction
+  - Restores state onto fresh runtime
+- `src/runtime/bootstrap.js`
+  - Prepares storage
+  - Installs Omeka when needed
+  - Applies blueprint state
+  - Handles autologin
+- `src/runtime/vfs.js`
+  - Mounts the readonly Omeka core bundle into the WASM filesystem
+- `scripts/dev-server.mjs`
+  - Serves the static app locally
+  - Proxies remote addon ZIP downloads back to the same origin for browser runtime fetches
+  - This proxy is local-only; production static hosting uses the external ZIP proxy configured in `playground.config.json`
 
-## Running locally
+### Storage Model
 
-The dev server is a tiny static server with an add-on ZIP proxy:
+This project no longer copies the entire Omeka tree into persistent storage on every boot.
+
+Current model (fully ephemeral — all state lives in Emscripten MEMFS):
+
+- Readonly core: hydrated into in-memory FS under `/www/omeka`
+- Mutable state: in-memory under `/persist` (not persisted to IndexedDB/OPFS)
+- Remote blueprint addons: stored under `/persist/addons` and symlinked into `/www/omeka/modules` or `/www/omeka/themes` at boot
+- Uploads: stored under `/persist/mutable/files`
+- Database/config/session data: stored in the mutable overlay
+- Crash recovery: DB and addon files are snapshotted from JS heap before runtime destruction and restored onto fresh runtimes
+
+Closing the tab destroys all state. This is by design — fresh install on each page load.
+Avoid reintroducing boot-time file-by-file copies of the full Omeka core into persistent storage.
+
+### Bundle and Manifest
+
+The Omeka bundle is built by the scripts in `scripts/`.
+
+Relevant files:
+
+- `scripts/build-omeka-bundle.sh`
+- `scripts/generate-manifest.mjs`
+- `lib/omeka-loader.js`
+- `src/runtime/manifest.js`
+
+If you change the bundle structure, also update manifest generation and runtime loading together.
+
+## GitHub Pages and Base Path Handling
+
+This project is deployed under a subpath:
+
+- Production base path: `/omeka-s-playground`
+
+That means absolute links like `/admin/site` are wrong in production unless they are rewritten
+to the scoped runtime path.
+
+### Important rule
+
+When modifying `sw.js`, preserve all three behaviors:
+
+1. App base path handling for static hosting in a subdirectory
+2. Scoped runtime routing under `/playground/<scope>/<runtime>/...`
+3. HTML response rewriting for Omeka-generated links and forms
+
+Omeka can emit URLs HTML-escaped, for example:
+
+```html
+href="&#x2F;admin&#x2F;site"
+```
+
+The service worker must handle those cases. If navigation works on first load but breaks after
+clicking inside the admin, inspect the HTML response body before assuming the routing layer is wrong.
+
+## Blueprints
+
+Blueprints are JSON files that describe the desired state of a playground instance.
+
+Relevant files:
+
+- `assets/blueprints/default.blueprint.json`
+- `assets/blueprints/blueprint-schema.json`
+- `src/shared/blueprint.js`
+
+Blueprints can define:
+
+- Site title, locale, timezone
+- Debug mode for development-style error visibility
+- Admin and other users
+- Landing page
+- Site creation
+- Items, item sets, and media
+- Modules and themes from bundled assets, direct ZIP URLs, or `omeka.org` slugs
+
+Blueprint input can come from the default bundled file, `?blueprint=` URL fetches, or `?blueprint-data=` base64url JSON payloads.
+
+When changing blueprint semantics, update both the schema and the runtime code that consumes it.
+
+## Configuration
+
+Runtime defaults live in:
+
+- `playground.config.json`
+- `src/shared/config.js`
+
+Important flags include:
+
+- `landingPath`
+- `autologin`
+- admin credentials and site defaults
+- `outboundHttp`
+- `addonProxyPath`
+- `addonProxyUrl`
+
+If you change autologin behavior, verify both first boot and reload behavior.
+If you change `outboundHttp`, `addonProxyPath`, or `addonProxyUrl`, verify both local-dev proxy behavior and the production ZIP proxy flow.
+
+## Development Conventions
+
+### JavaScript
+
+- The repo uses ESM. Keep imports/exports ESM-compatible.
+- Prefer small, explicit helpers over deeply coupled inline logic.
+- Keep browser code compatible with current Chromium-class browsers.
+- Avoid introducing framework dependencies unless explicitly requested.
+
+### Path Handling
+
+- Be careful with URL paths versus filesystem paths.
+- In service worker and shell code, prefer `URL` and explicit path helpers over ad-hoc string slicing.
+- In runtime FS code, keep POSIX-style paths.
+
+### Function Ordering
+
+- Prefer caller before callee when adding related functions in the same file.
+- Keep public/event-entry functions near the top of the local section.
+
+### Comments
+
+- Add comments only where logic is non-obvious.
+- Keep comments short and focused on why the code exists, not what a line literally does.
+
+## Linting, Formatting, and Testing
+
+Before committing or submitting a PR, always run:
 
 ```bash
-PORT=8087 node ./scripts/dev-server.mjs
-# or via the Makefile target:
-make serve PORT=8087
+make lint      # Run Biome linter — must pass with zero errors
+make format    # Auto-fix lint and formatting issues
+make test      # Run unit tests — all must pass
 ```
 
-CRITICAL gotchas:
+Biome is configured in `biome.json` and checks `src/`, `tests/`, and `scripts/`. Fix any lint errors before committing. Use `make format` to auto-fix formatting and safe lint issues.
 
-- The server binds to `process.env.PORT` (the Makefile passes `PORT=$(PORT)`,
-  default `8080`). A **privileged port (<1024) fails with `EACCES`** — always
-  use a high port, e.g. `8087`.
-- `dist/php-worker.bundle.js` and `index.html` **must exist** before the app
-  boots. If `dist/` is missing or stale, run **`make bundle`** first (which runs
-  `prepare` → `sync-browser-deps` + `prepare-runtime` + `build-worker`, then
-  builds the Omeka bundle). To only rebuild the worker after a source change:
-  `npm run build-worker`.
-- The dev server also serves `/__addon_proxy__?url=<encoded>` so the browser can
-  fetch remote add-on ZIPs same-origin (it falls back to `curl` when Node fetch
-  is TLS-fingerprint-blocked). In production the external proxy in
-  `playground.config.json` (`addonProxyUrl`) is used instead.
-
-Full build matrix: `make bundle-all` builds every supported Omeka version;
-`make up` is `bundle-all` + `serve`.
-
-## Scoped URL routing
-
-The shell lives at `/`. Verify the rest by booting and reading the live DOM.
-
-- The shell renders `#site-frame` whose `src` is
-  `remote.html?scope=<scopeId>&runtime=<runtimeId>&path=<path>`
-  (built by `resolveRemoteUrl` in `src/shared/paths.js`).
-- Inside `remote.html`, a **nested iframe** (`#remote-frame`) points at the real
-  scoped app path:
-  **`/playground/<scopeId>/<runtimeId><path>`**
-  (built by `buildScopedSitePath` in `src/shared/paths.js`).
-- `runtimeId` looks like **`php83-omeka420`** (`php<XY>-omeka<NNN>`, parsed by
-  `parseRuntimeId` in `src/shared/omeka-versions.js`). Default is
-  `php83-omeka420` (PHP 8.3 + Omeka S 4.2.0); `php83-omeka411` is also bundled.
-- `scopeId` is a `crypto.randomUUID()` minted by `getOrCreateScopeId`
-  (`src/shared/storage.js`) and stored in **sessionStorage**. It can also come
-  from a `?scope=` query param.
-- `sw.js` distinguishes unscoped/static requests from scoped/runtime requests,
-  rewrites redirects, and rewrites Omeka-generated HTML links/forms for the
-  GitHub Pages subpath (`/omeka-s-playground` in production). Omeka sometimes
-  emits HTML-escaped URLs (e.g. `href="&#x2F;admin&#x2F;site"`) — the SW handles
-  those. If navigation works on first load but breaks after clicking inside the
-  admin, inspect the HTML response body before blaming the routing layer.
-
-## Boot & readiness
-
-Boot is **slow** — the PHP-WASM runtime loads (~20 MB WASM + ~30 MB ICU) and the
-Omeka core (~19 MB ZIP, ~9 300 files) is extracted into MEMFS via PHP's native
-`ZipArchive`. Expect roughly **10–40 s**. Browser-automation navigation tools
-often time out while boot is still progressing — **boot continues; poll for
-readiness** instead of trusting a navigation timeout.
-
-Readiness signals (this is what the e2e test waits on,
-`tests/e2e/shell.spec.mjs`):
-
-- `#address-input` becomes **enabled**, and
-- `#site-frame`'s `src` attribute **contains `scope=`**.
-
-Progress is reported through a `BroadcastChannel` to the shell (`kind: "progress"`
-/ `"ready"` / `"error"` messages from `php-worker.js`).
-
-## Persistence model (Wave 4)
-
-Mutable state is journaled to **IndexedDB** via `@php-wasm/fs-journal`
-(`src/runtime/fs-persistence.js`), keyed by `scopeId`.
-
-- IndexedDB database name: **`omeka-fs-journal:<scopeId>`**
-  (prefix `omeka-fs-journal`, store name `ops`, debounced flush every 1500 ms).
-- Because `scopeId` is **sessionStorage**-based, persistence has *within-session
-  durability*: it **survives reloads and navigations within the same tab**, but
-  is lost when the tab closes (a new tab mints a new `scopeId` → fresh install).
-- On boot, `php-loader.js` replays the saved journal onto the fresh PHP instance
-  **before** Omeka bootstraps, so `$status->isInstalled()` finds the restored DB
-  and skips reinstall. Replay is resilient: a single un-appliable op (e.g. a
-  dangling `unlink` from media created in the isolated CLI runtime) is skipped
-  rather than bricking the reload.
-- Only `/persist` is journaled. Ephemeral SQLite sidecars
-  (`.sqlite-journal` / `.sqlite-wal` / `.sqlite-shm`) are skipped. OPcache is
-  intentionally **not** journaled.
-
-What lives under `/persist` (constants at the top of `src/runtime/bootstrap.js`):
-
-| Path | What |
-| --- | --- |
-| `/persist/mutable/db/omeka.sqlite` | the Omeka SQLite database |
-| `/persist/mutable/config/playground-state.json` | install/manifest/blueprint state |
-| `/persist/mutable/config/playground-prepend.php` | generated `auto_prepend_file` |
-| `/persist/mutable/files` | uploaded media (symlinked to `/www/omeka/files`) |
-| `/persist/mutable/session` | PHP session save path |
-| `/persist/mutable/logs` | logs |
-| `/persist/addons` | persisted add-on (module/theme) files |
-| `/persist/runtime/blueprint-media` | prefetched blueprint media files |
-| `/persist/runtime/content-seeded.json` | content-seed marker (see below) |
-
-**Reset / clean boot.** The `#reset-button` triggers a clean boot
-(`pendingCleanBoot = true` → `remote.html?...&clean=1`). `remote/main.js` reads
-`clean=1` and sends it to the worker, which calls `clearJournal(scopeId)`
-(wiping `omeka-fs-journal:<scopeId>`) and then re-installs from scratch. Note the
-top-window `/` URL does **not** read a bare `?clean=1`; the clean flag is carried
-on the *remote.html* URL, set by the reset button (or a blueprint URL override).
-
-### Persist DATA, not caches (the general lesson)
-
-Blueprint **content** (items + item sets) is seeded only **once**, guarded by the
-marker `/persist/runtime/content-seeded.json` keyed by the bundle/manifest
-signature (`buildInstallScript` in `src/runtime/bootstrap.js`). On later reloads
-the seed loops are skipped, so a user who deletes or edits a seeded item keeps
-that change. A **manifest change** (new signature) or a **reset** (which wipes
-`/persist`, removing the marker) reseeds. Sibling note: Moodle excludes
-`/persist/moodledata/(cache|localcache|temp|muc)` from journaling — same
-principle, persist real data, never caches.
-
-## Debugging recipes
-
-Run all of these **from the page console**. They use `await` at top level (paste
-into DevTools, which supports it).
-
-### Inspect the IndexedDB journal
-
-```js
-// 1. Find the journal DB(s) for the current scope.
-(await indexedDB.databases()).filter(d => d.name?.startsWith("omeka-fs-journal:"))
-
-// 2. Open it and dump the journaled ops (each op is {path, operation, ...}).
-//    The scope is most reliably read from the #site-frame src params; the active
-//    scopeId is also in sessionStorage under "omeka-playground:active".
-await new Promise((resolve) => {
-  const scope = new URL(document.querySelector("#site-frame").src).searchParams.get("scope");
-  const req = indexedDB.open("omeka-fs-journal:" + scope);
-  req.onsuccess = () => {
-    const tx = req.result.transaction("ops", "readonly");
-    const all = tx.objectStore("ops").getAll();
-    all.onsuccess = () => { console.table(all.result.map(o => ({ path: o.path, operation: o.operation }))); resolve(all.result); };
-  };
-});
-```
-
-### Derive the app base URL, then talk to Omeka
-
-```js
-// Base = /playground/<scope>/<runtime> — read it from the site-frame src params.
-const p = new URL(document.querySelector("#site-frame").src).searchParams;
-const base = `/playground/${p.get("scope")}/${p.get("runtime")}`;
-```
-
-**Admin / auth quirk.** The playground holds an admin session **server-side**
-(autologin runs at boot, credentials from `playground.config.json`:
-`admin` / `password` / `admin@example.com`). So fetching the admin dashboard with
-just the session cookie works — no login form:
-
-```js
-const html = await (await fetch(`${base}/admin`)).text();
-html.includes("/logout"); // true → you are the logged-in admin
-```
-
-**API reads (unauthenticated) work.** The Omeka REST API returns JSON-LD for
-public resources without keys:
-
-```js
-const items = await (await fetch(`${base}/api/items?per_page=100`)).json();
-```
-
-**API writes do NOT work with only a session cookie.** `DELETE`/`POST /api/...`
-require API keys and otherwise return
-`403 "Permission denied for the current user"`. Use the **admin controller
-actions** instead. Example — batch-delete items (read the CSRF token from the
-batch-delete form on the `/admin/item` browse page, then post it):
-
-```js
-const browse = await (await fetch(`${base}/admin/item`)).text();
-const csrf = browse.match(/name="(confirmform_csrf|csrf)"[^>]*value="([^"]*)"/)[2];
-const body = new URLSearchParams();
-body.set("confirmform_csrf", csrf);
-for (const id of [1, 2, 3]) body.append("resource_ids[]", String(id));
-await fetch(`${base}/admin/item/batch-delete`, {
-  method: "POST",
-  headers: { "content-type": "application/x-www-form-urlencoded" },
-  body: body.toString(),
-});
-```
-
-### Capture phpinfo / runtime diagnostics
-
-The shell has a phpinfo tab; programmatically the worker responds to a
-`capture-phpinfo` message and there is a SQLite probe at boot
-(`buildProbeScript` in `bootstrap.js`). If boot fails with a SQLite error, that
-probe output is the first thing to read.
-
-## Build & test
+### Typical syntax checks
 
 ```bash
-make lint     # Biome check — must pass with zero errors
-make format   # Biome check --fix (auto-fix)
-make test     # node --test tests/*.test.mjs
-make bundle   # prepare + build the default Omeka bundle (also: npm run build-worker)
-make test-e2e # Playwright (npm run test:e2e)
+node --check src/shared/blueprint.js
+node --check src/runtime/bootstrap.js
 ```
 
-Notes:
+### Manual validation areas
 
-- **Biome auto-wraps long lines.** Match its formatting (run `make format`) or
-  `make lint` fails on style.
-- After a source change, confirm it actually reached the worker bundle:
-  `grep <token> dist/php-worker.bundle.js`.
-- Unit tests are `node --test tests/*.test.mjs`. e2e is Playwright
-  (`tests/e2e/*.spec.mjs`, `playwright.config.mjs`; default base URL
-  `http://127.0.0.1:8085`, its `webServer` runs `make serve` on `PORT=8085`,
-  building the bundle first if `assets/manifests/latest.json` is absent).
+- First boot install
+- Reload behavior (fresh install each time — ephemeral)
+- Autologin flow to `/admin`
+- Navigation inside Omeka admin
+- GitHub Pages subpath behavior
+- Service worker updates after redeploy
 
-## CI gotchas
+If a change touches routing or HTML rewriting, prefer checking real browser behavior, not only syntax.
 
-- **CI runs `make test` WITHOUT `sync-browser-deps`**, so `vendor/` is absent
-  (it is gitignored, populated only by `npm run sync-browser-deps`). Therefore
-  import shared deps as **bare specifiers** (`fflate`, `@php-wasm/...`), **not**
-  `../vendor/...`, or the loader tests break. See `lib/omeka-loader.js` for the
-  correct pattern.
-- **Never `git add -A`.** It would commit local `.claude/` / `.omc/` artifacts.
-  Stage explicit files only.
-- **CodeQL / least privilege:** workflows set `permissions: contents: read`
-  (`.github/workflows/ci.yml`). Keep that — don't widen token scope.
-- **Two CI jobs** in `ci.yml`: `test` (syntax check + `make test` + `make lint`)
-  and `e2e` (Playwright boot smoke that builds the default bundle: git clone +
-  composer + runtime, then asserts the runtime boots). `pages.yml` deploys to
-  GitHub Pages and builds **all** Omeka versions.
+## Key Files
 
-## Common pitfalls
+- `index.html`: shell UI
+- `remote.html`: runtime host page
+- `sw.js`: service worker routing and HTML/link rewriting
+- `php-worker.js`: PHP worker bridge, boot lifecycle, and crash recovery
+- `src/runtime/php-loader.js`: creates PHP runtime via `@php-wasm/web`
+- `src/runtime/php-compat.js`: wraps `@php-wasm` API for compatibility with bootstrap/addons
+- `src/runtime/crash-recovery.js`: WASM crash detection, DB snapshot/restore
+- `playground.config.json`: runtime defaults
+- `src/runtime/bootstrap.js`: installation, config, blueprint application, autologin
+- `src/runtime/vfs.js`: readonly core bundle mounting
+- `src/runtime/manifest.js`: manifest loading
+- `src/shared/protocol.js`: shell/worker protocol definitions
+- `src/shared/storage.js`: browser persistence helpers
+- `src/styles/app.css`: shell styling
+- `scripts/esbuild.worker.mjs`: bundles php-worker.js into dist/
+- `Makefile`: common local workflow
 
-- Don't assume the app is hosted at `/`; production runs under
-  `/omeka-s-playground`. Use `URL` and the helpers in `src/shared/paths.js`.
-- Don't assume Omeka links are plain text; some are HTML-escaped.
-- Don't move the whole core into persistent storage, and don't break the
-  readonly-core / mutable-overlay separation.
-- Service-worker changes often need a hard refresh or worker reset to take
-  effect — verify from a clean scope when in doubt.
-- PHP can't open raw sockets; outbound HTTP goes through `fetch` and the
-  configured proxy/allowlist policy.
+## Common Pitfalls
+
+- Do not assume the app is hosted at `/`; production runs in a subdirectory.
+- Do not assume Omeka-generated links are plain text; some are HTML-escaped.
+- Do not assume PHP can open raw sockets to the internet; outbound HTTP flows through the browser's fetch API and the configured allowlist/proxy policy.
+- Do not move the entire core into persistent storage unless explicitly required.
+- Do not break the separation between readonly core and mutable overlay.
+- Do not forget that service worker changes often require a hard refresh or worker reset to verify.
+- Do not rely on stale shell state if `autologin` is enabled; saved `/login` paths may need to be ignored.
+
+## When Editing Specific Areas
+
+### If you edit `sw.js`
+
+- Re-check path scoping for both local root hosting and GitHub Pages subpath hosting
+- Validate redirect rewriting and HTML attribute rewriting together
+- Be conservative with external URLs and special schemes
+
+### If you edit `bootstrap.js`
+
+- Verify install idempotency
+- Verify persisted data survives reloads
+- Verify autologin does not block startup when credentials fail
+
+### If you edit bundle scripts
+
+- Keep the manifest schema and runtime readers in sync
+- Avoid changing output file names casually; deployment and loaders depend on them
+
+## Deployment Notes
+
+The project is intended for static deployment, especially GitHub Pages.
+
+After changes to `sw.js`, `remote.html`, or runtime boot files:
+
+- redeploy the site
+- force-refresh the browser or clear the old service worker
+- verify from a clean scope when possible
+
+## Reference Projects
+
+- WordPress Playground: architectural inspiration
+- Moodle Playground: bundle/build pipeline inspiration
+
+Use those as references, but prefer the actual conventions in this repository when they differ.
+
+## Debugging
+
+### By hand (in the browser)
+
+Serve the static app locally and open it in a Chromium-class browser:
+
+```bash
+make serve                 # PORT=8080 node ./scripts/dev-server.mjs (default)
+PORT=8087 make serve       # pick another port
+PORT=8087 node ./scripts/dev-server.mjs   # the same thing, directly
+```
+
+Then open `http://localhost:<port>/`. The dev server binds to `127.0.0.1`; a
+privileged port below `1024` fails with `EACCES`, so use something like `8087`.
+
+**Scoped routing.** The shell at `/` (`index.html` + `src/shell/main.js`) boots a
+Web Worker (`php-worker.js`, the PHP/WASM runtime) and a Service Worker (`sw.js`).
+The actual Omeka app is then served under `/playground/<scope>/<runtime>/…` and
+displayed inside the `#site-frame` iframe. `<runtime>` is a runtime id such as
+`php83-omeka420` (see `playground.config.json`); `<scope>` is a per-tab id stored
+in `sessionStorage` (`getOrCreateScopeId` in `src/shared/storage.js`), so all
+mutable state is scoped to that tab within its session.
+
+**Detecting "boot ready".** Boot is slow (the readonly core is extracted into the
+WASM filesystem before the installer runs), so poll rather than assume. The shell
+sets the `#site-frame` src to `remote.html?scope=<id>&runtime=<id>&path=…` and
+keeps `#address-input` disabled until the runtime is up. Boot is ready when
+`#address-input` is enabled and `#site-frame`'s `src` contains `scope=`:
+
+```js
+const ready = () =>
+  !document.querySelector("#address-input").disabled &&
+  /scope=/.test(document.querySelector("#site-frame").getAttribute("src") || "");
+```
+
+**Dumping the persistence journal.** Mutable `/persist` state (SQLite DB, uploads,
+config, the content-seeded marker) is journaled to IndexedDB by
+`src/runtime/fs-persistence.js`. The database name is
+`omeka-fs-journal:<scopeId>` and the operations live in the `ops` object store.
+Run this in the *page* console (the shell document, not the iframe):
+
+```js
+(async () => {
+  const dbs = await indexedDB.databases();
+  const name = dbs.map((d) => d.name).find((n) => n?.startsWith("omeka-fs-journal:"));
+  if (!name) return console.warn("no journal db yet — has it booted?");
+  const db = await new Promise((res, rej) => {
+    const r = indexedDB.open(name);
+    r.onsuccess = () => res(r.result);
+    r.onerror = () => rej(r.error);
+  });
+  const ops = await new Promise((res, rej) => {
+    const r = db.transaction("ops", "readonly").objectStore("ops").getAll();
+    r.onsuccess = () => res(r.result);
+    r.onerror = () => rej(r.error);
+  });
+  console.log(name, ops.length, ops);
+})();
+```
+
+**App recipes (run from the page console).** Derive the scoped base path from the
+iframe, then talk to Omeka directly:
+
+```js
+const src = document.querySelector("#site-frame").getAttribute("src");
+const base = decodeURIComponent(new URL(src, location).searchParams.get("path") || "/");
+// or read it straight off the scoped path:
+const scoped = "/playground/" +
+  new URL(src, location).searchParams.get("scope") + "/" +
+  new URL(src, location).searchParams.get("runtime");
+```
+
+- **Public read (no auth):** `GET ${scoped}/api/items?per_page=100` returns the
+  items as JSON-LD. This works unauthenticated.
+- **Admin session:** autologin (`autologin: true` in `playground.config.json`,
+  performed in `src/runtime/bootstrap.js`) means the admin session is already
+  active. `GET ${scoped}/admin` shows the dashboard; `${scoped}/logout` ends it.
+- **API WRITES return 403.** The Omeka REST API rejects writes without API keys,
+  and the playground does not provision keys. To mutate data, drive the admin
+  controllers instead. To delete items, POST to the admin batch-delete endpoint:
+
+  ```
+  POST ${scoped}/admin/item/batch-delete?...
+  fields:
+    <csrf-name>      # the hidden CSRF field from the batch-delete <form> on /admin/item
+    resource_ids[]   # one per item id to delete
+  ```
+
+  Read the CSRF field name and value out of the batch-delete form on the
+  `${scoped}/admin/item` browse page first (Omeka names it like
+  `batch_delete_selected_csrf`); the token is request-scoped, so fetch the page
+  and reuse the token from the same response.
+
+**Reset.** The `#reset-button` (handler in `src/shell/main.js`) triggers a clean
+boot (`?clean=1`), which calls `clearJournal(scopeId)` in
+`src/runtime/fs-persistence.js` to wipe the `/persist` journal — including the
+`/persist/runtime/content-seeded.json` marker, so blueprint content reseeds on
+the next boot.
+
+**Admin credentials:** `admin` / `password`, email `admin@example.com` (from the
+`admin` block in `playground.config.json`).
+
+### With the e2e suite (Playwright)
+
+End-to-end tests live in `tests/e2e/*.spec.mjs` and run with Playwright:
+
+```bash
+npm run test:e2e     # = playwright test
+npx playwright test  # equivalent
+make test-e2e        # wraps npm run test:e2e
+```
+
+Config is in `playwright.config.mjs`: tests run serially (`fullyParallel: false`)
+against `http://127.0.0.1:8085`, and the `webServer` block builds the bundle if
+needed then runs `make serve` on port `8085`.
+
+`shell.spec.mjs` covers the persistence round-trip: boot → confirm an
+`omeka-fs-journal:<scopeId>` IndexedDB exists → wait past the 1500ms debounced
+flush → reload in the same tab (sessionStorage keeps the scope) → the runtime
+reboots by replaying the journal instead of doing a clean install.
+
+Gotchas:
+
+- **Run each sibling playground's e2e on its own.** `webServer.reuseExistingServer`
+  is enabled outside CI, and the sibling PHP-WASM playgrounds share a dev-server
+  port. Concurrent Playwright runs across the sibling repos reuse each other's
+  server and cross-contaminate — one repo's tests end up hitting another app's
+  shell. Run them one repo at a time (or give each its own port / set
+  `PLAYWRIGHT_BASE_URL` + `PLAYWRIGHT_EXTERNAL_SERVER=1`).
+- **A full `page.reload()` can hang on the `load` event.** On reload the shell
+  promotes the scoped WASM app to the top window, so the `load` event may never
+  settle. Reload with `await page.reload({ waitUntil: "commit" })` and then poll
+  for readiness (`#address-input` enabled and `#site-frame` src containing
+  `scope=`) instead of waiting for `load`.


### PR DESCRIPTION
The previous PR (#78) replaced the whole AGENTS.md with a from-scratch rewrite. This restores the original AGENTS.md verbatim and only appends a new `## Debugging` section at the end.

The appended section covers manual browser debugging (serving locally, scoped `/playground/<scope>/<runtime>/…` routing, boot-readiness polling, dumping the IndexedDB persistence journal, public API reads vs 403 API writes / admin batch-delete, and reset) and the Playwright e2e suite (how to run it, the persistence round-trip in `shell.spec.mjs`, and the reuse-existing-server cross-contamination + `page.reload` hang gotchas).