### PR TITLE
feat(shell): move version config into the Info panel, drop the gear popover

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,9 +71,6 @@
               <rect x="13" y="0.5" width="4.5" height="15" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/>
             </svg>
           </button>
-          <button type="button" id="settings-button" class="icon-button" aria-label="Open settings" aria-expanded="false" title="Settings">
-            <span aria-hidden="true">&#9881;</span>
-          </button>
         </div>
       </header>
 
@@ -98,20 +95,52 @@
           </div>
 
           <section id="info-panel" class="side-panel__content" role="tabpanel" aria-labelledby="info-tab" data-panel-view="info">
-            <div class="settings-field">
-              <span>Omeka version</span>
-              <span id="current-omeka-label" class="settings-value">-</span>
-            </div>
-            <div class="settings-field">
-              <span>PHP version</span>
-              <span id="current-php-label" class="settings-value">-</span>
-            </div>
-            <div class="settings-field">
-              <span>Runtime ID</span>
-              <span id="current-runtime-label" class="settings-value">-</span>
-            </div>
-            <div class="settings-actions">
-              <button type="button" id="reset-button" class="danger">Reset Playground</button>
+            <div class="info-stack">
+              <div class="info-section">
+                <div class="section-label">
+                  <span>Configuration</span>
+                  <span id="config-status" class="status-pill"><span class="dot"></span>Running</span>
+                </div>
+                <div class="field">
+                  <label for="info-omeka-version">Omeka version</label>
+                  <select id="info-omeka-version"></select>
+                </div>
+                <div class="field">
+                  <label for="info-php-version">PHP version</label>
+                  <select id="info-php-version"></select>
+                </div>
+                <div id="config-warning" class="warn-banner is-hidden" role="alert">
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M8 1.6 1 14h14L8 1.6Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
+                    <path d="M8 6.4v3.3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                    <circle cx="8" cy="11.7" r="0.6" fill="currentColor"/>
+                  </svg>
+                  <span>Applying will reset Omeka S to a clean install. All current data will be lost.</span>
+                </div>
+                <div class="action-row">
+                  <button type="button" id="config-apply" class="danger grow is-hidden">Apply &amp; Reset</button>
+                </div>
+              </div>
+
+              <hr class="divider">
+
+              <div class="info-section">
+                <div class="section-label"><span>Runtime</span></div>
+                <div class="value-row">
+                  <span class="vr-key">Runtime ID</span>
+                  <button type="button" id="runtime-id-chip" class="copy-chip" title="Copy runtime ID">
+                    <span id="runtime-id-value">-</span>
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                      <rect x="5" y="5" width="8" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
+                      <path d="M11 5V3.5A1.5 1.5 0 0 0 9.5 2h-5A1.5 1.5 0 0 0 3 3.5v7A1.5 1.5 0 0 0 4.5 12H5" stroke="currentColor" stroke-width="1.3" fill="none"/>
+                    </svg>
+                  </button>
+                </div>
+                <div class="action-row">
+                  <button type="button" id="reset-button" class="danger grow">Reset Playground</button>
+                </div>
+                <p class="muted-help">Reset reinstalls the current configuration from scratch. Your data is wiped.</p>
+              </div>
             </div>
           </section>
 
@@ -166,30 +195,6 @@
             </a>
           </footer>
         </aside>
-      </div>
-    </div>
-
-    <div id="settings-overlay" class="settings-popover-overlay" aria-hidden="true"></div>
-    <div id="settings-popover" class="settings-popover" role="dialog" aria-label="Playground Settings">
-      <h2 class="settings-popover__title">Playground Settings</h2>
-
-      <label class="settings-popover__field">
-        <span>Omeka S Version</span>
-        <select id="settings-omeka-version"></select>
-      </label>
-
-      <label class="settings-popover__field">
-        <span>PHP Version</span>
-        <select id="settings-php-version"></select>
-      </label>
-
-      <div class="settings-popover__warning">
-        Applying new settings will reset the Omeka site to its initial state. All current data will be lost.
-      </div>
-
-      <div class="settings-popover__actions">
-        <button type="button" id="settings-cancel">Cancel</button>
-        <button type="button" id="settings-apply" class="danger">Apply &amp; Reset</button>
       </div>
     </div>
 

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -10,7 +10,6 @@ import {
   DEFAULT_OMEKA_VERSION,
   DEFAULT_PHP_VERSION,
   getCompatiblePhpVersions,
-  getOmekaVersionMetadata,
   OMEKA_VERSIONS,
   parseQueryParams,
   resolveRuntimeSelection,
@@ -47,16 +46,13 @@ const els = {
   homeButton: document.querySelector("#home-button"),
   adminButton: document.querySelector("#admin-button"),
   reset: document.querySelector("#reset-button"),
-  settingsButton: document.querySelector("#settings-button"),
-  settingsPopover: document.querySelector("#settings-popover"),
-  settingsOverlay: document.querySelector("#settings-overlay"),
-  settingsOmekaVersion: document.querySelector("#settings-omeka-version"),
-  settingsPhpVersion: document.querySelector("#settings-php-version"),
-  settingsApply: document.querySelector("#settings-apply"),
-  settingsCancel: document.querySelector("#settings-cancel"),
-  currentOmekaLabel: document.querySelector("#current-omeka-label"),
-  currentPhpLabel: document.querySelector("#current-php-label"),
-  currentRuntimeLabel: document.querySelector("#current-runtime-label"),
+  infoOmekaVersion: document.querySelector("#info-omeka-version"),
+  infoPhpVersion: document.querySelector("#info-php-version"),
+  configStatus: document.querySelector("#config-status"),
+  configWarning: document.querySelector("#config-warning"),
+  configApply: document.querySelector("#config-apply"),
+  runtimeIdChip: document.querySelector("#runtime-id-chip"),
+  runtimeIdValue: document.querySelector("#runtime-id-value"),
   infoPanel: document.querySelector("#info-panel"),
   infoTab: document.querySelector("#info-tab"),
   sidePanel: document.querySelector("#side-panel"),
@@ -393,95 +389,88 @@ function bindServiceWorkerMessages() {
   });
 }
 
-function populateSettingsModal() {
-  if (!els.settingsOmekaVersion || !els.settingsPhpVersion) {
+function populateConfigSelects() {
+  if (!els.infoOmekaVersion || !els.infoPhpVersion) {
     return;
   }
 
-  els.settingsOmekaVersion.innerHTML = "";
+  // Populate Omeka version dropdown
+  els.infoOmekaVersion.innerHTML = "";
   for (const entry of OMEKA_VERSIONS) {
     const option = document.createElement("option");
     option.value = entry.version;
     option.textContent = entry.label;
-    els.settingsOmekaVersion.append(option);
+    els.infoOmekaVersion.append(option);
   }
-  els.settingsOmekaVersion.value = currentOmekaVersion;
+  els.infoOmekaVersion.value = currentOmekaVersion;
 
+  // Populate PHP version dropdown based on selected Omeka version
   updatePhpVersionDropdown(currentOmekaVersion);
-  els.settingsPhpVersion.value = currentPhpVersion;
+  els.infoPhpVersion.value = currentPhpVersion;
 }
 
 function updatePhpVersionDropdown(omekaVersion) {
-  if (!els.settingsPhpVersion) {
+  if (!els.infoPhpVersion) {
     return;
   }
 
   const compatible = getCompatiblePhpVersions(omekaVersion);
-  const previousValue = els.settingsPhpVersion.value;
-  els.settingsPhpVersion.innerHTML = "";
+  const previousValue = els.infoPhpVersion.value;
+  els.infoPhpVersion.innerHTML = "";
   for (const version of compatible) {
     const option = document.createElement("option");
     option.value = version;
     option.textContent = `PHP ${version}`;
-    els.settingsPhpVersion.append(option);
+    els.infoPhpVersion.append(option);
   }
 
+  // Keep current selection if still compatible, otherwise fall back
   if (compatible.includes(previousValue)) {
-    els.settingsPhpVersion.value = previousValue;
+    els.infoPhpVersion.value = previousValue;
   } else if (compatible.includes(currentPhpVersion)) {
-    els.settingsPhpVersion.value = currentPhpVersion;
+    els.infoPhpVersion.value = currentPhpVersion;
   } else if (compatible.includes(DEFAULT_PHP_VERSION)) {
-    els.settingsPhpVersion.value = DEFAULT_PHP_VERSION;
+    els.infoPhpVersion.value = DEFAULT_PHP_VERSION;
   } else {
-    els.settingsPhpVersion.value = compatible[0];
+    els.infoPhpVersion.value = compatible[0];
   }
 }
 
-function updateCurrentVersionLabels() {
-  const meta = getOmekaVersionMetadata(currentOmekaVersion);
-  if (els.currentOmekaLabel) {
-    els.currentOmekaLabel.textContent = meta
-      ? meta.label
-      : currentOmekaVersion || "-";
-  }
-  if (els.currentPhpLabel) {
-    els.currentPhpLabel.textContent = `PHP ${currentPhpVersion}`;
-  }
-  if (els.currentRuntimeLabel) {
-    els.currentRuntimeLabel.textContent = currentRuntimeId;
-  }
-}
-
-function openSettingsPopover() {
-  if (!els.settingsPopover) {
+// Reflect the applied runtime in the Info panel: when the selected versions
+// differ from what is actually running the config is "dirty". Changing a version
+// is destructive (it resets the site), so the Apply button stays hidden and the
+// warning stays hidden until the selection actually differs.
+function refreshDirtyState() {
+  if (!els.infoOmekaVersion || !els.infoPhpVersion) {
     return;
   }
-  populateSettingsModal();
-  els.settingsPopover.classList.add("is-open");
-  els.settingsOverlay.classList.add("is-open");
-  els.settingsOverlay.setAttribute("aria-hidden", "false");
-  els.settingsButton.setAttribute("aria-expanded", "true");
-  const firstInput = els.settingsPopover.querySelector("select");
-  if (firstInput) {
-    firstInput.focus();
+  const dirty =
+    els.infoOmekaVersion.value !== currentOmekaVersion ||
+    els.infoPhpVersion.value !== currentPhpVersion;
+
+  if (els.configStatus) {
+    els.configStatus.className = dirty ? "dirty-note" : "status-pill";
+    els.configStatus.innerHTML = dirty
+      ? '<span class="dot"></span>Unsaved'
+      : '<span class="dot"></span>Running';
   }
+  // Changing a version is destructive; the Apply button and warning only appear
+  // once the selection differs from what is running. To revert, reselect the
+  // original version — the dirty state clears itself.
+  els.configWarning?.classList.toggle("is-hidden", !dirty);
+  els.configApply?.classList.toggle("is-hidden", !dirty);
 }
 
-function closeSettingsPopover() {
-  if (!els.settingsPopover) {
-    return;
+function updateConfigState() {
+  if (els.runtimeIdValue) {
+    els.runtimeIdValue.textContent = currentRuntimeId;
   }
-  els.settingsPopover.classList.remove("is-open");
-  els.settingsOverlay.classList.remove("is-open");
-  els.settingsOverlay.setAttribute("aria-hidden", "true");
-  els.settingsButton.setAttribute("aria-expanded", "false");
-  els.settingsButton.focus();
+  refreshDirtyState();
 }
 
-function applySettingsAndReset() {
-  const newOmeka = els.settingsOmekaVersion?.value;
-  const newPhp = els.settingsPhpVersion?.value;
-  closeSettingsPopover();
+function applyConfigAndReset() {
+  const newOmeka = els.infoOmekaVersion?.value;
+  const newPhp = els.infoPhpVersion?.value;
 
   if (newOmeka === currentOmekaVersion && newPhp === currentPhpVersion) {
     return;
@@ -543,44 +532,36 @@ async function main() {
       : previous?.path || preferredPath;
   els.address.value = currentPath;
 
-  updateCurrentVersionLabels();
+  populateConfigSelects();
+  updateConfigState();
 
-  if (els.settingsOmekaVersion) {
-    els.settingsOmekaVersion.addEventListener("change", (event) => {
-      updatePhpVersionDropdown(event.target.value);
+  // Configuration (Info panel) event listeners
+  if (els.infoOmekaVersion) {
+    els.infoOmekaVersion.addEventListener("change", () => {
+      updatePhpVersionDropdown(els.infoOmekaVersion.value);
+      refreshDirtyState();
     });
   }
-
-  // Settings popover event listeners
-  if (els.settingsButton) {
-    els.settingsButton.addEventListener("click", () => {
-      const isOpen = els.settingsPopover?.classList.contains("is-open");
-      if (isOpen) {
-        closeSettingsPopover();
-      } else {
-        openSettingsPopover();
+  if (els.infoPhpVersion) {
+    els.infoPhpVersion.addEventListener("change", refreshDirtyState);
+  }
+  if (els.configApply) {
+    els.configApply.addEventListener("click", applyConfigAndReset);
+  }
+  if (els.runtimeIdChip) {
+    els.runtimeIdChip.addEventListener("click", () => {
+      navigator.clipboard?.writeText(currentRuntimeId || "");
+      const label = els.runtimeIdValue;
+      if (!label) {
+        return;
       }
+      const original = label.textContent;
+      label.textContent = "✓ copied";
+      setTimeout(() => {
+        label.textContent = original;
+      }, 1400);
     });
   }
-  if (els.settingsOverlay) {
-    els.settingsOverlay.addEventListener("click", closeSettingsPopover);
-  }
-  if (els.settingsCancel) {
-    els.settingsCancel.addEventListener("click", closeSettingsPopover);
-  }
-  if (els.settingsApply) {
-    els.settingsApply.addEventListener("click", applySettingsAndReset);
-  }
-
-  // Close popover on Escape
-  document.addEventListener("keydown", (event) => {
-    if (
-      event.key === "Escape" &&
-      els.settingsPopover?.classList.contains("is-open")
-    ) {
-      closeSettingsPopover();
-    }
-  });
 
   bindShellChannel();
   bindServiceWorkerMessages();

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -30,6 +30,9 @@
   --chrome-active: rgba(255, 255, 255, 0.25);
   --color-danger: #dc3545;
   --color-danger-hover: #c82333;
+  --color-danger-light: rgba(220, 53, 69, 0.08);
+  --color-danger-border: rgba(220, 53, 69, 0.25);
+  --color-success: #2f9e44;
 
   /* Semantic */
   --bg-page: var(--color-gray-100);
@@ -673,86 +676,176 @@ button.danger:hover {
   }
 }
 
-/* -- Settings popover (replaces modal) --------------------- */
-.settings-popover {
-  position: fixed;
-  top: calc(var(--navbar-height) + var(--space-sm));
-  right: var(--space-lg);
-  z-index: 100;
-  width: 360px;
-  max-width: calc(100vw - 32px);
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-popover);
-  padding: var(--space-xl);
-  display: none;
+/* ── Config / Info building blocks (sidebar redesign) ── */
+.info-stack {
+  display: grid;
+  gap: var(--space-xl);
+}
+.info-section {
+  display: grid;
+  gap: var(--space-md);
 }
 
-.settings-popover.is-open {
-  display: block;
-}
-
-.settings-popover__title {
-  margin: 0 0 var(--space-lg);
-  font-size: 15px;
+.section-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
   font-weight: 600;
-  color: var(--text-heading);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
-.settings-popover__field {
+.field {
   display: grid;
   gap: var(--space-xs);
-  margin-bottom: var(--space-lg);
 }
-
-.settings-popover__field span {
-  color: var(--text-muted);
+.field > label {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
+  color: var(--text-muted);
 }
-
-.settings-popover__field select {
-  padding: 7px 12px;
+.field select {
+  padding: 8px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-input);
   color: var(--text);
-  font: inherit;
 }
-
-.settings-popover__field select:focus {
+.field select:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--color-maroon-light);
+  outline: none;
+}
+.field select:disabled {
+  background: var(--bg-surface-muted);
+  color: var(--text-muted);
+  cursor: not-allowed;
 }
 
-.settings-popover__warning {
+.value-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: 9px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+.value-row:last-child {
+  border-bottom: 0;
+}
+.value-row .vr-key {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-success);
+}
+.status-pill .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-success);
+}
+
+.dirty-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+}
+.dirty-note .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.warn-banner {
+  display: flex;
+  gap: var(--space-sm);
   padding: var(--space-md);
   border-radius: var(--radius-md);
   background: var(--color-maroon-light);
   border: 1px solid var(--color-maroon-border);
   color: var(--color-maroon-hover);
-  font-size: 13px;
+  font-size: 12.5px;
   line-height: 1.45;
-  margin-bottom: var(--space-lg);
+}
+.warn-banner svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
 }
 
-.settings-popover__actions {
+.action-row {
   display: flex;
-  justify-content: flex-end;
   gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+.action-row .grow {
+  flex: 1;
 }
 
-/* Overlay behind popover for outside-click dismiss */
-.settings-popover-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 99;
+.copy-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: ui-monospace, "SFMono-Regular", monospace;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-heading);
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  cursor: pointer;
+}
+.copy-chip:hover {
+  border-color: var(--color-gray-400);
+  background: var(--color-gray-100);
+}
+
+.divider {
+  height: 1px;
+  background: var(--border-light);
+  border: 0;
+  margin: 0;
+}
+
+.muted-help {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.45;
+  margin: 0;
+}
+
+.reveal {
+  animation: reveal 0.18s ease;
+}
+@keyframes reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* generic hide utility (used by the Info-panel config: warning + apply button) */
+.is-hidden {
   display: none;
-}
-
-.settings-popover-overlay.is-open {
-  display: block;
 }
 
 /* -- Responsive -------------------------------------------- */
@@ -803,11 +896,5 @@ button.danger:hover {
 
   .browser-toolbar__actions {
     justify-content: flex-end;
-  }
-
-  .settings-popover {
-    right: var(--space-sm);
-    left: var(--space-sm);
-    width: auto;
   }
 }

--- a/tests/e2e/shell.spec.mjs
+++ b/tests/e2e/shell.spec.mjs
@@ -6,7 +6,10 @@ async function waitForRuntimeReady(page) {
   // The address bar stays disabled until the PHP runtime has booted and the
   // site frame is scoped — booting requires the core bundle to have been
   // extracted into MEMFS (now via PHP ZipArchive), so this also guards against
-  // a core-extraction regression making boot too slow / fail.
+  // a core-extraction regression making boot too slow / fail. The runtime-id
+  // chip in the Info panel is populated as soon as the runtime is selected, so
+  // it doubles as a readiness signal.
+  await expect(page.locator("#runtime-id-value")).not.toHaveText("-");
   await expect(page.locator("#address-input")).toBeEnabled();
   await expect(page.locator("#site-frame")).toHaveAttribute("src", /scope=/);
 }
@@ -32,6 +35,57 @@ test("toggles the runtime side panel", async ({ page }) => {
     "true",
   );
   await expect(page.locator("#side-panel")).not.toHaveClass(/is-collapsed/);
+});
+
+test("info panel hosts the version config with a dirty-state apply", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  // The floating settings popover and gear button are gone — the version config
+  // now lives in the Info panel (single source of truth).
+  await expect(page.locator("#settings-button")).toHaveCount(0);
+  await expect(page.locator("#settings-popover")).toHaveCount(0);
+
+  await page.locator("#panel-toggle-button").click();
+
+  const omekaOptions = await page.locator("#info-omeka-version option").count();
+  expect(omekaOptions).toBeGreaterThan(0);
+  const phpOptions = await page.locator("#info-php-version option").count();
+  expect(phpOptions).toBeGreaterThan(0);
+
+  // Clean state: no Apply button and no destructive warning.
+  await expect(page.locator("#config-apply")).toBeHidden();
+  await expect(page.locator("#config-warning")).toBeHidden();
+
+  // Changing a version reveals the Apply button + the warning. Reselecting the
+  // original value clears the dirty state (no Discard button needed). Prefer the
+  // Omeka select if it offers more than one version, else fall back to PHP.
+  const omekaCurrent = await page.locator("#info-omeka-version").inputValue();
+  const omekaOther = await page
+    .locator("#info-omeka-version option")
+    .evaluateAll(
+      (opts, cur) => opts.find((o) => o.value !== cur)?.value,
+      omekaCurrent,
+    );
+  const dirtySelect = omekaOther ? "#info-omeka-version" : "#info-php-version";
+  const current = await page.locator(dirtySelect).inputValue();
+  const other = await page
+    .locator(`${dirtySelect} option`)
+    .evaluateAll(
+      (opts, cur) => opts.find((o) => o.value !== cur)?.value,
+      current,
+    );
+
+  expect(other).toBeTruthy();
+  await page.locator(dirtySelect).selectOption(other);
+  await expect(page.locator("#config-apply")).toBeVisible();
+  await expect(page.locator("#config-warning")).toBeVisible();
+
+  await page.locator(dirtySelect).selectOption(current);
+  await expect(page.locator("#config-apply")).toBeHidden();
+  await expect(page.locator("#config-warning")).toBeHidden();
 });
 
 test("persists /persist to IndexedDB and reboots from it on reload", async ({


### PR DESCRIPTION
## What

Replaces the floating settings popover (and its ⚙ gear toolbar button + overlay) with an inline version configuration in the sidebar **Info** panel — single source of truth — mirroring the approved moodle-playground sidebar redesign.

### Configuration section
- Always-visible **Omeka version** and **PHP version** selects, populated from `OMEKA_VERSIONS` / `getCompatiblePhpVersions` (the same source the popover used). Changing the Omeka select re-filters compatible PHP versions.
- Status indicator next to the "Configuration" label: `status-pill` → "Running" while the selection matches the running runtime; `dirty-note` → "Unsaved" when it differs.
- A data-loss `warn-banner` ("Applying will reset Omeka S to a clean install. All current data will be lost.") and an **Apply & Reset** button — both start hidden and appear only when the selection is dirty. Reselecting the original value re-hides them and flips the pill back to "Running". No Discard / disabled button.
- Apply reuses the original popover flow: sets `omeka` + `php` URL params, clears the saved scope session, and reloads for a fresh runtime.

### Runtime section
- Copyable **Runtime ID** chip (`button.copy-chip`) that briefly shows "✓ copied".
- The existing **Reset Playground** button (same id + handler) plus a `muted-help` line.

### Cleanup
- Removed the read-only `#current-omeka-label` / `#current-php-label` / `#current-runtime-label` rows and their JS (`updateCurrentVersionLabels`, popover open/close/apply functions, popover `els`).
- CSS: added the sidebar-redesign building blocks verbatim, a generic `.is-hidden` rule, and the `--color-success` / `--color-danger-light` / `--color-danger-border` tokens; deleted all `.settings-popover*` styles.

### Tests
- e2e readiness signal now keys off `#runtime-id-value` (replacing the removed runtime label).
- New "info panel hosts the version config with a dirty-state apply" test: asserts `#settings-button` / `#settings-popover` count 0, the selects have options, Apply + warning are hidden when clean, visible after changing a version, and hidden again after reselecting the original.

## Verification
- `make lint` → passes (only pre-existing warnings in `tests/install-script-boot.test.mjs` + `biome.json`).
- `make test` → 99/99 unit tests pass.
- Playwright e2e not run locally (sibling repos share dev-server port 8085); CI runs it fresh.

## Notes
Omeka's version model is **app-version + PHP** (Omeka S select + PHP select; runtime id like `php83-omeka420`), so the dirty comparison checks both selects — no PHP-only adaptation needed.