### PR TITLE
Load ICU data from unpkg

### DIFF
--- a/scripts/esbuild.worker.mjs
+++ b/scripts/esbuild.worker.mjs
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import { dirname, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
-const require = createRequire(import.meta.url);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoDir = resolvePath(scriptDir, "..");
 
@@ -61,15 +59,18 @@ const stripUnusedPhpVersions = {
   },
 };
 
-// @php-wasm/web >= 3.1.22 references "../intl/shared/icu.dat", expecting a
-// sibling @php-wasm/intl package that is never published to npm. The file still
-// ships inside @php-wasm/web itself, so redirect the import to the existing copy.
-const phpWasmWebDir = dirname(require.resolve("@php-wasm/web/package.json"));
+const ICU_DATA_URL =
+  "https://unpkg.com/@php-wasm/web@3.1.36/shared/icu.dat";
 const icuDatShim = {
   name: "php-wasm-intl-icu-shim",
   setup(api) {
-    api.onResolve({ filter: /\.\.\/intl\/shared\/icu\.dat$/ }, () => ({
-      path: resolvePath(phpWasmWebDir, "shared/icu.dat"),
+    api.onResolve({ filter: /(^|\/)(?:intl\/shared|shared)\/icu\.dat$/ }, () => ({
+      path: "external-icu-data-url",
+      namespace: "external-icu-data-url",
+    }));
+    api.onLoad({ filter: /.*/, namespace: "external-icu-data-url" }, () => ({
+      loader: "js",
+      contents: `export default ${JSON.stringify(ICU_DATA_URL)};`,
     }));
   },
 };

--- a/scripts/esbuild.worker.mjs
+++ b/scripts/esbuild.worker.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -81,6 +81,8 @@ const icuDatShim = {
     }));
   },
 };
+
+rmSync(resolvePath(repoDir, "dist"), { force: true, recursive: true });
 
 await build({
   entryPoints: ["php-worker.js"],

--- a/scripts/esbuild.worker.mjs
+++ b/scripts/esbuild.worker.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
+const require = createRequire(import.meta.url);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoDir = resolvePath(scriptDir, "..");
 
@@ -59,15 +61,20 @@ const stripUnusedPhpVersions = {
   },
 };
 
-const ICU_DATA_URL =
-  "https://unpkg.com/@php-wasm/web@3.1.36/shared/icu.dat";
+const phpWasmWebPackage = JSON.parse(
+  readFileSync(require.resolve("@php-wasm/web/package.json"), "utf8"),
+);
+const ICU_DATA_URL = `https://unpkg.com/@php-wasm/web@${phpWasmWebPackage.version}/shared/icu.dat`;
 const icuDatShim = {
   name: "php-wasm-intl-icu-shim",
   setup(api) {
-    api.onResolve({ filter: /(^|\/)(?:intl\/shared|shared)\/icu\.dat$/ }, () => ({
-      path: "external-icu-data-url",
-      namespace: "external-icu-data-url",
-    }));
+    api.onResolve(
+      { filter: /(^|\/)(?:intl\/shared|shared)\/icu\.dat$/ },
+      () => ({
+        path: "external-icu-data-url",
+        namespace: "external-icu-data-url",
+      }),
+    );
     api.onLoad({ filter: /.*/, namespace: "external-icu-data-url" }, () => ({
       loader: "js",
       contents: `export default ${JSON.stringify(ICU_DATA_URL)};`,


### PR DESCRIPTION
Summary
- Resolve @php-wasm/web icu.dat imports to an unpkg URL built from the installed @php-wasm/web package version.
- Avoid emitting the local ~29 MB icu.dat asset in the worker build.
- Clean dist before rebuilding so stale icu-*.dat files do not get deployed accidentally.
- Keep both import shapes covered: ../intl/shared/icu.dat and ./shared/icu.dat.

Validation
- make lint
- node --check scripts/esbuild.worker.mjs
- npm run build-worker
- bundle contains https://unpkg.com/@php-wasm/web@<installed-version>/shared/icu.dat and no icu-*.dat reference
- find dist -type f -size +25M returns no files
- npm test