### PR TITLE
Configure Cloudflare Pages previews

### DIFF
--- a/.github/workflows/cloudflare-pages-cleanup.yml
+++ b/.github/workflows/cloudflare-pages-cleanup.yml
@@ -1,0 +1,39 @@
+name: Cloudflare Pages Cleanup
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types: [opened, reopened, synchronize, closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-pages-cleanup-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Wrangler
+        run: npm install --no-save wrangler@latest
+
+      - name: Clean stale Cloudflare Pages deployments
+        env:
+          CLOUDFLARE_ACCOUNT_ID: 8cdbd0eb9712b3a9a3e9b860fd87ed6c
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PAGES_PROJECT: omeka-s-playground
+          CLOUDFLARE_PAGES_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          CLOUDFLARE_PAGES_DELETE_BRANCH_ALL: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+        run: node scripts/cleanup-cloudflare-pages.mjs

--- a/.github/workflows/cloudflare-pages-cleanup.yml
+++ b/.github/workflows/cloudflare-pages-cleanup.yml
@@ -18,18 +18,22 @@ concurrency:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    env:
+      HAS_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Wrangler
+        if: env.HAS_CLOUDFLARE_API_TOKEN == 'true'
         run: npm install --no-save wrangler@latest
 
       - name: Clean stale Cloudflare Pages deployments
+        if: env.HAS_CLOUDFLARE_API_TOKEN == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: 8cdbd0eb9712b3a9a3e9b860fd87ed6c
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -37,3 +41,7 @@ jobs:
           CLOUDFLARE_PAGES_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           CLOUDFLARE_PAGES_DELETE_BRANCH_ALL: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
         run: node scripts/cleanup-cloudflare-pages.mjs
+
+      - name: Skip cleanup without Cloudflare token
+        if: env.HAS_CLOUDFLARE_API_TOKEN != 'true'
+        run: echo "CLOUDFLARE_API_TOKEN is not configured; skipping cleanup."

--- a/scripts/build-cloudflare-pages.sh
+++ b/scripts/build-cloudflare-pages.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+make prepare
+make bundle-all
+python -m pip install -r requirements-docs.txt
+
+rm -rf _site site
+mkdir -p _site/docs _site/dist
+rsync -a ./ ./_site/ \
+  --exclude ".git/" \
+  --exclude ".github/" \
+  --exclude ".venv/" \
+  --exclude ".cache/" \
+  --exclude "_site/" \
+  --exclude "docs/" \
+  --exclude "node_modules/" \
+  --exclude "site/"
+mkdocs build --strict --site-dir _site/docs
+touch _site/.nojekyll

--- a/scripts/cleanup-cloudflare-pages.mjs
+++ b/scripts/cleanup-cloudflare-pages.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+const projectName = process.env.CLOUDFLARE_PAGES_PROJECT;
+const targetBranch = process.env.CLOUDFLARE_PAGES_BRANCH || "";
+const deleteBranchAll = process.env.CLOUDFLARE_PAGES_DELETE_BRANCH_ALL === "true";
+const dryRun = process.env.CLOUDFLARE_PAGES_CLEANUP_DRY_RUN === "true";
+
+if (!projectName) {
+  throw new Error("CLOUDFLARE_PAGES_PROJECT is required");
+}
+
+if (!process.env.CLOUDFLARE_ACCOUNT_ID) {
+  throw new Error("CLOUDFLARE_ACCOUNT_ID is required");
+}
+
+function wrangler(args, options = {}) {
+  const result = spawnSync("npx", ["wrangler", ...args], {
+    encoding: "utf8",
+    stdio: options.stdio || "pipe",
+  });
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    throw new Error(`wrangler ${args.join(" ")} failed\n${detail}`);
+  }
+  return result.stdout;
+}
+
+const deployments = JSON.parse(
+  wrangler(["pages", "deployment", "list", "--project-name", projectName, "--json"]),
+);
+
+const seen = new Set();
+const deletions = [];
+
+for (const deployment of deployments) {
+  const branch = deployment.Branch;
+  const environment = deployment.Environment;
+  const key = `${environment}:${branch}`;
+
+  if (deleteBranchAll && targetBranch && branch === targetBranch) {
+    deletions.push(deployment);
+    continue;
+  }
+
+  if (seen.has(key)) {
+    deletions.push(deployment);
+    continue;
+  }
+
+  seen.add(key);
+}
+
+if (deletions.length === 0) {
+  console.log(`No stale Cloudflare Pages deployments found for ${projectName}.`);
+  process.exit(0);
+}
+
+for (const deployment of deletions) {
+  const label = `${deployment.Id} (${deployment.Environment}/${deployment.Branch}/${deployment.Source})`;
+  if (dryRun) {
+    console.log(`[dry-run] Would delete ${label}`);
+    continue;
+  }
+
+  try {
+    wrangler(
+      [
+        "pages",
+        "deployment",
+        "delete",
+        deployment.Id,
+        "--project-name",
+        projectName,
+        "--force",
+      ],
+      { stdio: "pipe" },
+    );
+    console.log(`Deleted ${label}`);
+  } catch (error) {
+    console.log(`Skipped ${label}: ${error.message}`);
+  }
+}

--- a/scripts/cleanup-cloudflare-pages.mjs
+++ b/scripts/cleanup-cloudflare-pages.mjs
@@ -4,7 +4,8 @@ import { spawnSync } from "node:child_process";
 
 const projectName = process.env.CLOUDFLARE_PAGES_PROJECT;
 const targetBranch = process.env.CLOUDFLARE_PAGES_BRANCH || "";
-const deleteBranchAll = process.env.CLOUDFLARE_PAGES_DELETE_BRANCH_ALL === "true";
+const deleteBranchAll =
+  process.env.CLOUDFLARE_PAGES_DELETE_BRANCH_ALL === "true";
 const dryRun = process.env.CLOUDFLARE_PAGES_CLEANUP_DRY_RUN === "true";
 
 if (!projectName) {
@@ -28,7 +29,14 @@ function wrangler(args, options = {}) {
 }
 
 const deployments = JSON.parse(
-  wrangler(["pages", "deployment", "list", "--project-name", projectName, "--json"]),
+  wrangler([
+    "pages",
+    "deployment",
+    "list",
+    "--project-name",
+    projectName,
+    "--json",
+  ]),
 );
 
 const seen = new Set();
@@ -53,7 +61,9 @@ for (const deployment of deployments) {
 }
 
 if (deletions.length === 0) {
-  console.log(`No stale Cloudflare Pages deployments found for ${projectName}.`);
+  console.log(
+    `No stale Cloudflare Pages deployments found for ${projectName}.`,
+  );
   process.exit(0);
 }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "omeka-s-playground"
+pages_build_output_dir = "./_site"
+compatibility_date = "2026-06-07"


### PR DESCRIPTION
Summary
- Add Cloudflare Pages repo config for omeka-s-playground.
- Add a Cloudflare build script that assembles the Pages output into _site.
- Add a cleanup workflow that keeps only the latest deployment per branch/environment and attempts to delete PR branch deployments when the PR closes.

Cloudflare Pages settings
- Project: omeka-s-playground
- Production branch: main
- Build command: ./scripts/build-cloudflare-pages.sh
- Build output directory: _site
- Preview deployments: enabled for all non-production branches
- PR comments: enabled

Required GitHub secret
- CLOUDFLARE_API_TOKEN with Pages Write permission for cleanup workflow.

Validation
- bash -n scripts/build-cloudflare-pages.sh
- node --check scripts/cleanup-cloudflare-pages.mjs
- Dry-run cleanup against omeka-s-playground