### PR TITLE
ci(cloudflare): preview button in PR comment + remove comment on close

### DIFF
--- a/.github/workflows/cloudflare-pages-cleanup.yml
+++ b/.github/workflows/cloudflare-pages-cleanup.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: cloudflare-pages-cleanup-${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -45,3 +46,21 @@ jobs:
       - name: Skip cleanup without Cloudflare token
         if: env.HAS_CLOUDFLARE_API_TOKEN != 'true'
         run: echo "CLOUDFLARE_API_TOKEN is not configured; skipping cleanup."
+
+      # When the PR closes, the preview deployment is deleted above — also remove
+      # the sticky preview comment so it does not linger pointing at a dead URL.
+      - name: Remove preview comment on close
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          MARKER='<!-- cf-preview -->'
+          CID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq "map(select(.body|startswith(\"$MARKER\")))|.[0].id // empty")
+          if [ -n "$CID" ]; then
+            gh api -X DELETE "repos/$REPO/issues/comments/$CID" >/dev/null && echo "Removed preview comment $CID"
+          else
+            echo "No preview comment to remove."
+          fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,7 @@ concurrency:
 env:
   CLOUDFLARE_ACCOUNT_ID: 8cdbd0eb9712b3a9a3e9b860fd87ed6c
   CLOUDFLARE_PAGES_PROJECT: omeka-s-playground
+  PREVIEW_BUTTON_IMG: https://img.shields.io/badge/%E2%96%B6%20Try%20on%20the%20Playground-f98012?style=for-the-badge
 
 jobs:
   build:
@@ -108,8 +109,13 @@ jobs:
           PREVIEW_URL: ${{ steps.cf_preview.outputs.url }}
         run: |
           MARKER='<!-- cf-preview -->'
-          BODY=$(printf '%s\n🚀 **Cloudflare Pages preview**: %s\nBranch `%s`' \
-            "$MARKER" "${PREVIEW_URL:-deploy failed — see workflow logs}" "$HEAD_REF")
+          if [ -n "$PREVIEW_URL" ]; then
+            BODY=$(printf '%s\n### Cloudflare Pages preview\n<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="Try on the Playground" height="51"></a>\n\nBranch `%s` · <%s>' \
+              "$MARKER" "$PREVIEW_URL" "$PREVIEW_BUTTON_IMG" "$HEAD_REF" "$PREVIEW_URL")
+          else
+            BODY=$(printf '%s\n### Cloudflare Pages preview\n⚠️ Preview deploy failed — see the workflow logs.\n\nBranch `%s`' \
+              "$MARKER" "$HEAD_REF")
+          fi
           CID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq "map(select(.body|startswith(\"$MARKER\")))|.[0].id // empty")
           if [ -n "$CID" ]; then

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -96,8 +96,11 @@ jobs:
           out=$(npx --yes wrangler@4 pages deploy _site \
             --project-name="$CLOUDFLARE_PAGES_PROJECT" \
             --branch="$HEAD_REF" --commit-dirty=true 2>&1 | tee /dev/stderr)
-          url=$(printf '%s\n' "$out" | grep -oE "https://[a-z0-9-]+\.${CLOUDFLARE_PAGES_PROJECT}\.pages\.dev" | head -n1)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+          proj="$CLOUDFLARE_PAGES_PROJECT"
+          urls=$(printf '%s\n' "$out" | grep -oE "https://[a-z0-9-]+\.${proj}\.pages\.dev" | sort -u)
+          deploy_url=$(printf '%s\n' "$urls" | grep -E "https://[0-9a-f]{8}\.${proj}\." | head -n1)
+          alias_url=$(printf '%s\n' "$urls" | grep -vE "https://[0-9a-f]{8}\.${proj}\." | head -n1)
+          { echo "deploy_url=$deploy_url"; echo "alias_url=$alias_url"; } >> "$GITHUB_OUTPUT"
 
       - name: Comment preview URL on PR
         if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -106,15 +109,25 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
-          PREVIEW_URL: ${{ steps.cf_preview.outputs.url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DEPLOY_URL: ${{ steps.cf_preview.outputs.deploy_url }}
+          ALIAS_URL: ${{ steps.cf_preview.outputs.alias_url }}
         run: |
           MARKER='<!-- cf-preview -->'
-          if [ -n "$PREVIEW_URL" ]; then
-            BODY=$(printf '%s\n### Cloudflare Pages preview\n<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="Try on the Playground" height="51"></a>\n\nBranch `%s` · <%s>' \
-              "$MARKER" "$PREVIEW_URL" "$PREVIEW_BUTTON_IMG" "$HEAD_REF" "$PREVIEW_URL")
+          LOGO='https://user-images.githubusercontent.com/23264/106598434-9e719e00-654f-11eb-9e59-6167043cfa01.png'
+          SHA7=$(printf '%s' "$HEAD_SHA" | cut -c1-7)
+          ALIAS="$ALIAS_URL"
+          if [ -z "$ALIAS" ]; then
+            slug=$(printf '%s' "$HEAD_REF" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-28 | sed -E 's/-+$//')
+            ALIAS="https://${slug}.${CLOUDFLARE_PAGES_PROJECT}.pages.dev"
+          fi
+          DEPLOY="${DEPLOY_URL:-$ALIAS}"
+          if [ -n "$DEPLOY_URL" ] || [ -n "$ALIAS_URL" ]; then
+            BODY=$(printf '%s\n## Deploying %s with &nbsp;<img alt="Cloudflare Pages" src="%s" width="16">&nbsp; Cloudflare Pages\n\n<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="Try on the Playground" height="51"></a>\n\n|  |  |\n| :-- | :-- |\n| **Latest commit** | `%s` |\n| **Preview URL (branch)** | %s |\n| **Deployment URL (commit)** | %s |' \
+              "$MARKER" "$CLOUDFLARE_PAGES_PROJECT" "$LOGO" "$ALIAS" "$PREVIEW_BUTTON_IMG" "$SHA7" "$ALIAS" "$DEPLOY")
           else
-            BODY=$(printf '%s\n### Cloudflare Pages preview\n⚠️ Preview deploy failed — see the workflow logs.\n\nBranch `%s`' \
-              "$MARKER" "$HEAD_REF")
+            BODY=$(printf '%s\n## Deploying %s with Cloudflare Pages\n\n⚠️ Preview deploy failed — see the workflow logs.\n\nBranch `%s`' \
+              "$MARKER" "$CLOUDFLARE_PAGES_PROJECT" "$HEAD_REF")
           fi
           CID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq "map(select(.body|startswith(\"$MARKER\")))|.[0].id // empty")


### PR DESCRIPTION
Follow-up polish to the Direct Upload preview flow:

- The sticky PR preview comment now shows a **"Try on the Playground"** button linking to the deployment, instead of a bare URL.
- When the PR is closed/merged, `cloudflare-pages-cleanup.yml` already deletes the preview deployment — now it also **removes the sticky comment** so it doesn't linger pointing at a dead URL (adds `pull-requests: write`).