### PR TITLE
feat(branding): Try-on-Playground button (omeka dark red)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   CLOUDFLARE_ACCOUNT_ID: 8cdbd0eb9712b3a9a3e9b860fd87ed6c
   CLOUDFLARE_PAGES_PROJECT: omeka-s-playground
-  PREVIEW_BUTTON_IMG: https://img.shields.io/badge/%E2%96%B6%20Try%20on%20the%20Playground-f98012?style=for-the-badge
+  PREVIEW_BUTTON_IMG: https://raw.githubusercontent.com/ateeducacion/omeka-s-playground/main/assets/playground-preview-button.svg
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
   <img src=".github/screenshot.png" alt="Omeka S Playground" width="600">
 </p>
 
+<p align="center">
+  <a href="https://omeka-s-playground.pages.dev/" target="_blank" rel="noopener noreferrer">
+    <img src="assets/playground-preview-button.svg" alt="Try on Omeka S Playground" width="224">
+  </a>
+</p>
+
 [Live demo](https://ateeducacion.github.io/omeka-s-playground/) · [Documentation](docs/) · [Blueprints](docs/blueprint-json.md)
 
 > Run a full Omeka S site in the browser — no server required.

--- a/assets/playground-preview-button.svg
+++ b/assets/playground-preview-button.svg
@@ -1,0 +1,5 @@
+<svg width="447" height="104" viewBox="0 0 447 104" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Try on Omeka S Playground">
+  <rect width="447" height="104" rx="8" fill="#822433"/>
+  <path d="M50 34 L50 70 L80 52 Z" fill="#ffffff"/>
+  <text x="100" y="52" dominant-baseline="central" text-anchor="start" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="30" font-weight="700" fill="#ffffff" textLength="328" lengthAdjust="spacingAndGlyphs">Try on Omeka S Playground</text>
+</svg>


### PR DESCRIPTION
Adds `assets/playground-preview-button.svg` — a branded **Try on Omeka S Playground** button in the playground's own header colour (`#822433`, dark red), same 447×104 shape as the moodle/nextcloud buttons. Wired into the PR preview comment (replaces the shields.io fallback) and added to the README.