### PR TITLE
fix(persistence): reset persisted env when the blueprint changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,3 +503,32 @@ Gotchas:
   settle. Reload with `await page.reload({ waitUntil: "commit" })` and then poll
   for readiness (`#address-input` enabled and `#site-frame` src containing
   `scope=`) instead of waiting for `load`.
+
+## Persistence model (per-tab storage + blueprint reset)
+
+Mutable state under `/persist` is journaled to IndexedDB (`omeka-fs-journal:<scope>`) via
+`@php-wasm/fs-journal`, so it survives reloads. Key facts for future work:
+
+- **Per-tab, within-session.** `scopeId` lives in `sessionStorage`, so each
+  browser tab/window has its own environment. Opening the playground in a new tab
+  starts clean — nothing is shared (only *duplicating* a tab copies
+  `sessionStorage`). State is lost when the tab closes.
+- **A different blueprint starts fresh.** The persisted env is keyed by the
+  blueprint *source* — `blueprintSourceKey(href)` in `src/shared/paths.js`
+  (`url:<value>` for `?blueprint-url=`, `inline:<hash>` for `?blueprint=` /
+  `?blueprint-data=`, else `default`) — remembered per scope in `sessionStorage`
+  (`blueprint-source:<scope>`). Loading a **different** blueprint in the same tab
+  forces a clean boot (discards the previous `/persist` and installs fresh);
+  **reloading the same blueprint keeps the data.** (Same intent as WordPress
+  Playground, which serves URL blueprints as temporary by default and keys
+  persisted sites per site-slug.)
+- **Clean boot wiring.** On a clean boot the shell adds `&clean=1` to the
+  `#site-frame` remote URL; the worker then `clearJournal`s and **re-starts
+  journaling** (`initFsPersistence` runs after the clear in
+  `src/runtime/php-loader.js`) so the fresh env persists on later reloads. The
+  `#reset-button` triggers the same path.
+- **Flush.** On each debounced flush the journal collapses ops *before* hydrating
+  (`collapseAndHydrate` = `hydrateUpdateFileOps(php, normalizeFilesystemOperations(ops))`)
+  so a heavy install that rewrites the SQLite DB hundreds of times doesn't OOM.
+- **Inspect:** `await indexedDB.databases()` → open `omeka-fs-journal:<scope>` → read the
+  `ops` object store.

--- a/src/runtime/php-loader.js
+++ b/src/runtime/php-loader.js
@@ -95,11 +95,13 @@ export function createPhpRuntime(
         const { clearJournal, initFsPersistence } = await import(
           "./fs-persistence.js"
         );
+        // On a clean boot (reset / blueprint change), wipe the old journal first;
+        // then ALWAYS start journaling so the fresh env persists on later reloads
+        // (a same-blueprint reload then reuses it instead of reinstalling).
         if (forceCleanBoot) {
           await clearJournal(scopeId);
-        } else {
-          await initFsPersistence(php, scopeId);
         }
+        await initFsPersistence(php, scopeId);
       }
 
       php.writeFile(

--- a/src/shared/paths.js
+++ b/src/shared/paths.js
@@ -132,3 +132,29 @@ export function buildScopedSitePath(scopeId, runtimeId, path = "/") {
     `playground/${scopeId}/${runtimeId}${normalized}`,
   ).replace(/\/{2,}/gu, "/");
 }
+
+function djb2(value) {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+// Stable identity of the blueprint a URL points at. The shell compares it across
+// reloads to decide whether to reset the persisted env: a different blueprint
+// source => different key => clean boot; the same source => same key => keep the
+// persisted data. Keyed by the source (URL value / inline param), not the
+// resolved object, so it stays stable across reloads.
+export function blueprintSourceKey(href = window.location.href) {
+  const params = new URL(href).searchParams;
+  const url = params.get("blueprint-url");
+  if (url) {
+    return `url:${url}`;
+  }
+  const inline = params.get("blueprint") ?? params.get("blueprint-data");
+  if (inline) {
+    return `inline:${djb2(inline)}`;
+  }
+  return "default";
+}

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -14,7 +14,11 @@ import {
   parseQueryParams,
   resolveRuntimeSelection,
 } from "../shared/omeka-versions.js";
-import { hasBlueprintUrlOverride, resolveRemoteUrl } from "../shared/paths.js";
+import {
+  blueprintSourceKey,
+  hasBlueprintUrlOverride,
+  resolveRemoteUrl,
+} from "../shared/paths.js";
 import { createShellChannel } from "../shared/protocol.js";
 import {
   clearScopeSession,
@@ -71,7 +75,7 @@ let activeBlueprint;
 let remoteFrameBooted = false;
 let uiLocked = true;
 const remoteReloadToken = 0;
-let pendingCleanBoot = hasBlueprintUrlOverride(window.location.href);
+let pendingCleanBoot = false;
 let latestPhpInfoHtml = "";
 const CONTROL_RELOAD_KEY = `omeka-playground:${scopeId}:sw-controlled`;
 
@@ -497,6 +501,19 @@ async function main() {
   config = await loadPlaygroundConfig();
   activeBlueprint = await resolveBlueprintForShell(scopeId, config);
   updateBlueprintTextarea();
+
+  // Reset the persisted env when the blueprint changed since the last boot in
+  // this tab: a different blueprint must install fresh, not replay the previous
+  // env (which the install gate would otherwise reuse). Reloading the same
+  // blueprint keeps the data; a different tab is already clean (per-tab scopeId).
+  const blueprintKey = blueprintSourceKey(window.location.href);
+  const blueprintStoreKey = `blueprint-source:${scopeId}`;
+  const previousBlueprintKey = window.sessionStorage.getItem(blueprintStoreKey);
+  if (previousBlueprintKey !== null && previousBlueprintKey !== blueprintKey) {
+    pendingCleanBoot = true;
+  }
+  window.sessionStorage.setItem(blueprintStoreKey, blueprintKey);
+
   const previous = loadSessionState(scopeId);
   const preferredPath =
     activeBlueprint?.landingPage || config.landingPath || "/";

--- a/tests/blueprint-source-key.test.mjs
+++ b/tests/blueprint-source-key.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { blueprintSourceKey } from "../src/shared/paths.js";
+
+// The shell resets the persisted /persist when the blueprint *source* changes, so
+// loading a different blueprint in a tab installs fresh instead of replaying the
+// previous env. blueprintSourceKey is the stable per-source identity it compares.
+test("blueprintSourceKey: different blueprint => different key, same => same, bare => default", () => {
+  const a = "https://x/?blueprint-url=https://h/a.json";
+  const b = "https://x/?blueprint-url=https://h/b.json";
+
+  assert.notEqual(blueprintSourceKey(a), blueprintSourceKey(b));
+  assert.equal(blueprintSourceKey(a), blueprintSourceKey(a));
+  assert.equal(blueprintSourceKey("https://x/"), "default");
+
+  const i1 = "https://x/?blueprint-data=AAAA";
+  const i2 = "https://x/?blueprint-data=BBBB";
+  assert.notEqual(blueprintSourceKey(i1), blueprintSourceKey(i2));
+  assert.notEqual(blueprintSourceKey(i1), blueprintSourceKey(a));
+});


### PR DESCRIPTION
Same fix as moodle. In a tab with a persisted env, loading a **different** `?blueprint-url=` didn't load it (old `/persist` replayed, install gate skipped); and the shell wiped on every blueprint-url load (so reloading the same one reinstalled). **Part A (shell):** key the env by blueprint *source* (`blueprintSourceKey`), stored per scope; clean-boot only when it changed → different blueprint = fresh, same reload = persists, different tab = clean. **Part B (runtime):** a clean boot now always `initFsPersistence` after the optional `clearJournal`, so the fresh env persists on later reloads. Unit test for `blueprintSourceKey`. `make test` 101/101 ✅ · `make lint` ✅ (pre-existing warnings only).