### PR TITLE
feat(blueprint): support module asset overlays (assets[])

### DIFF
--- a/assets/blueprints/blueprint-schema.json
+++ b/assets/blueprints/blueprint-schema.json
@@ -164,6 +164,19 @@
                     }
                   }
                 ]
+              },
+              "assets": {
+                "type": "array",
+                "description": "Extra ZIP payloads overlaid onto the installed module directory after the module is extracted. Each archive is unpacked into 'destination' (relative to the module root); a single top-level wrapper folder is stripped, mirroring module extraction.",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["url", "destination"],
+                  "properties": {
+                    "url": { "type": "string", "format": "uri-reference" },
+                    "destination": { "type": "string", "minLength": 1 }
+                  }
+                }
               }
             }
           }

--- a/src/runtime/addons.js
+++ b/src/runtime/addons.js
@@ -594,6 +594,41 @@ export async function mountPersistedAddons({ php, omekaRoot }) {
   }
 }
 
+// Normalize the optional `assets` list on an add-on spec. Each asset overlays
+// an extra ZIP payload (e.g. a separately published static editor bundle) onto
+// the installed add-on directory after the add-on itself is extracted.
+function resolveAddonAssets(spec) {
+  if (!Array.isArray(spec.assets)) {
+    return [];
+  }
+  return spec.assets
+    .map((asset) => ({
+      url: String(asset?.url || "").trim(),
+      destination: String(asset?.destination || "").trim(),
+    }))
+    .filter((asset) => asset.url && asset.destination);
+}
+
+// Fold the asset list into the cache fingerprint so changing an asset URL or
+// destination busts the cached add-on and re-extracts everything.
+function assetsFingerprint(assets) {
+  if (!assets.length) {
+    return "";
+  }
+  return `|assets:${assets
+    .map((asset) => `${asset.url}->${asset.destination}`)
+    .join(",")}`;
+}
+
+// Resolve (and harden) an asset destination relative to the add-on root.
+function resolveAssetTarget(persistedPath, destination) {
+  const relative = normalizeArchivePath(destination);
+  if (!relative || isUnsafeArchivePath(relative)) {
+    throw new Error(`Unsafe add-on asset destination "${destination}".`);
+  }
+  return `${persistedPath}/${relative}`.replace(/\/{2,}/gu, "/");
+}
+
 async function materializeAddon({
   FS,
   kind,
@@ -618,10 +653,13 @@ async function materializeAddon({
     };
   }
 
+  const assets = resolveAddonAssets(spec);
+  const fingerprint = `${source.fingerprint}${assetsFingerprint(assets)}`;
+
   const existingManifest = readJsonSync(FS, manifestPath);
   const hasCachedFiles = directoryHasFiles(FS, persistedPath);
   const cacheHit =
-    existingManifest?.fingerprint === source.fingerprint && hasCachedFiles;
+    existingManifest?.fingerprint === fingerprint && hasCachedFiles;
 
   if (!cacheHit) {
     publish(`Fetching ${kind} "${spec.name}".`, 0.53);
@@ -634,11 +672,25 @@ async function materializeAddon({
     publish(`Extracting ${kind} "${spec.name}".`, 0.57);
     await writeArchiveToFs(FS, persistedPath, zipBytes);
 
+    // Overlay any declared asset archives (e.g. a separately published static
+    // editor bundle) onto the add-on directory. writeArchiveToFs strips a
+    // single top-level wrapper folder, so an archive that wraps its payload in
+    // "static/" lands directly under the requested destination.
+    for (const asset of assets) {
+      const assetTarget = resolveAssetTarget(persistedPath, asset.destination);
+      publish(`Fetching asset for ${kind} "${spec.name}".`, 0.56);
+      const assetBytes = await fetchBytes(
+        buildDownloadUrl(asset.url, proxyBaseUrl),
+      );
+      await writeArchiveToFs(FS, assetTarget, assetBytes);
+    }
+
     writeJsonSync(FS, manifestPath, {
       name: spec.name,
       kind,
-      fingerprint: source.fingerprint,
+      fingerprint,
       source,
+      assets,
       downloadedAt: new Date().toISOString(),
     });
   }

--- a/src/shared/blueprint.js
+++ b/src/shared/blueprint.js
@@ -252,6 +252,26 @@ function normalizeAddonSource(input) {
   throw new Error(`Unsupported blueprint addon source type "${type}".`);
 }
 
+// Normalize the optional `assets` overlay list on an add-on entry. Each asset
+// is an extra ZIP unpacked into a path relative to the installed add-on (used,
+// for example, to drop the shared static editor bundle into the module).
+function normalizeAddonAssets(input) {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input
+    .map((asset) => {
+      const url = absolutizeUrl(asset?.url || "");
+      const destination = String(asset?.destination || "").trim();
+      if (!url || !destination) {
+        return null;
+      }
+      return { url, destination };
+    })
+    .filter(Boolean);
+}
+
 function normalizeAddonCollection(input, kind) {
   if (!Array.isArray(input)) {
     return [];
@@ -264,6 +284,11 @@ function normalizeAddonCollection(input, kind) {
         name: String(entry?.name || entry || "").trim(),
         source: normalizeAddonSource(entry?.source),
       };
+
+      const assets = normalizeAddonAssets(entry?.assets);
+      if (assets.length) {
+        normalized.assets = assets;
+      }
 
       if (kind === "module") {
         normalized.state =

--- a/tests/blueprint.test.mjs
+++ b/tests/blueprint.test.mjs
@@ -140,6 +140,35 @@ describe("normalizeBlueprint", () => {
     assert.equal(result.modules[0].state, "activate");
   });
 
+  it("passes through module asset overlays and drops incomplete ones", () => {
+    const result = normalizeBlueprint(
+      {
+        modules: [
+          {
+            name: "ExeLearning",
+            state: "activate",
+            source: { type: "url", url: "https://example.com/module.zip" },
+            assets: [
+              {
+                url: "https://example.com/editor.zip",
+                destination: "dist/static",
+              },
+              { url: "", destination: "skip-no-url" },
+              { url: "https://example.com/x.zip", destination: "" },
+            ],
+          },
+        ],
+      },
+      baseConfig,
+    );
+    assert.equal(result.modules[0].assets.length, 1);
+    assert.equal(
+      result.modules[0].assets[0].url,
+      "https://example.com/editor.zip",
+    );
+    assert.equal(result.modules[0].assets[0].destination, "dist/static");
+  });
+
   it("throws on duplicate module names", () => {
     assert.throws(
       () =>


### PR DESCRIPTION
## What

Add an optional `assets` array to module specs in the blueprint:

```json
{
  "name": "ExeLearning",
  "state": "activate",
  "source": { "type": "url", "url": ".../omeka-s-exelearning/archive/refs/heads/main.zip" },
  "assets": [
    { "url": ".../exelearning/releases/download/v4.0.0/exelearning-static-v4.0.0.zip", "destination": "dist/static" }
  ]
}
```

Each asset is a ZIP fetched (through the configured proxy, like the module source) and unpacked into a path **relative to the installed module**, after the module itself is extracted. `writeArchiveToFs` strips a single top-level wrapper folder, so an archive that wraps its payload in `static/` lands directly under the destination — `destination: "dist/static"` → `module/dist/static/...`.

## Why

This lets a module pull in a separately published bundle at boot **without baking it into the module ZIP**. The eXeLearning module ([exelearning/omeka-s-exelearning](https://github.com/exelearning/omeka-s-exelearning)) uses it to load the shared static editor release, so the playground boots with a working editor instead of requiring the manual *Download & Install Editor* button — and the editor (byte-identical across all eXeLearning plugins) is referenced once rather than duplicated.

## Details

- The asset list is folded into the add-on **cache fingerprint**, so changing an asset URL/destination busts the cache and re-extracts.
- Destinations are normalized and hardened against path traversal (reuses `normalizeArchivePath` / `isUnsafeArchivePath`).
- The `assets` field is preserved through blueprint normalization (it was previously dropped) and added to the schema.
- Unit test added for the normalization passthrough; full suite green (`node --test`).

> Pairs with the eXeLearning module PR. This host change must be deployed first for that preview to load the editor.