### PR TITLE
ci(pages): allow manual production deploy via workflow_dispatch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: actions/configure-pages@v6
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
       - uses: actions/setup-node@v6
         with:
@@ -74,14 +74,14 @@ jobs:
           touch _site/.nojekyll
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
       # ── Cloudflare Pages (Direct Upload) ──
       - name: Deploy to Cloudflare Pages (production)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: npx --yes wrangler@4 pages deploy _site --project-name="$CLOUDFLARE_PAGES_PROJECT" --branch=main --commit-dirty=true
@@ -138,7 +138,7 @@ jobs:
           fi
 
   deploy:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Why

The Omeka core bundle is built at deploy time by cloning the Omeka fork branches (`feature/experimental-sqlite-support*`). When those branches change (e.g. a SQLite-compat fix) but `omeka-s-playground` itself has no new commit, there's no easy way to re-publish: the deploy steps were gated on `github.event_name == 'push'`, so a manual **Run workflow** (`workflow_dispatch`) only built the bundles and skipped the actual deploy.

## What

Allow `workflow_dispatch` to deploy, by extending the four push-only gates:

- `actions/configure-pages`
- `actions/upload-pages-artifact`
- Cloudflare Pages (production) deploy
- the `github-pages` `deploy` job

Each now runs on `github.event_name == 'push' || github.event_name == 'workflow_dispatch'`. PR-preview steps (gated on `pull_request`) are unchanged.

## Effect

After merge, the site can be re-published on demand from **Actions → Deploy Pages → Run workflow** (branch `main`), with no empty commit. Because the bundle build re-clones the fork branches each run, a manual dispatch picks up the latest fork changes.

## Notes

- YAML validated (parses; triggers `push`, `pull_request`, `workflow_dispatch`).
- No app/runtime code touched, so Biome lint/tests are unaffected.