### PR TITLE
chore(proxy): re-sync zip-proxy-worker.js with canonical (Moodle langpack support)

### DIFF
--- a/scripts/zip-proxy-worker.js
+++ b/scripts/zip-proxy-worker.js
@@ -10,17 +10,23 @@
 //
 // 1. Generic proxy mode (legacy): ?url={full_url}
 //    Proxies supported direct URLs with CORS headers. This includes ZIP downloads,
-//    GitHub-hosted text/binary resources, FacturaScripts plugin pages, and
-//    omeka.org / dev.omeka.org resources (plugin/module pages and downloads).
+//    GitHub-hosted text/binary resources, FacturaScripts plugin pages,
+//    omeka.org / dev.omeka.org resources (plugin/module pages and downloads), and
+//    Nextcloud / ownCloud public share links (/s/{token}[/download]) on any host.
 //
-// 2. GitHub proxy mode: ?repo={owner/repo}[&branch=...][&pr=...][&commit=...][&release=...][&asset=...][&atom=...]
+// 2. GitHub proxy mode: ?repo={owner/repo}[&branch=...][&pr=...][&commit=...][&release=...][&asset=...][&atom=...][&path=...]
 //    Builds the correct GitHub URL from semantic parameters and proxies the response.
+//    With &path={file} it serves a single raw file at the given ref (default
+//    branch when no ref is given) with CORS — e.g. a blueprint.json living in
+//    the repo. The ref travels as a query param, so refs with slashes
+//    (feat/x) are handled losslessly.
 //
 // Environment variables (optional):
 //   GITHUB_TOKEN – A GitHub personal access token to raise API rate limits from 60 to 5000 req/hour.
 
 const GITHUB_API = "https://api.github.com";
 const GITHUB_BASE = "https://github.com";
+const GITHUB_RAW = "https://raw.githubusercontent.com";
 
 export default {
   async fetch(request, env) {
@@ -71,6 +77,7 @@ export default {
           commit: "?repo={owner/repo}&commit={sha}",
           release: "?repo={owner/repo}&release={tag}",
           asset: "?repo={owner/repo}&release={tag}&asset={filename}",
+          raw_file: "?repo={owner/repo}&path={path}[&branch={branch}]",
           atom_releases: "?repo={owner/repo}&atom=releases",
           atom_tags: "?repo={owner/repo}&atom=tags",
         },
@@ -89,6 +96,20 @@ async function handleGitHubProxy(params, env) {
 
   if (!repo?.includes("/")) {
     return jsonResponse({ error: "Invalid repo format. Use owner/repo." }, 400);
+  }
+
+  // Raw file at a ref (e.g. a blueprint.json checked into the repo), served
+  // with CORS. The ref is a query param, so refs with slashes work. Resolves
+  // the ref from branch/ref/commit/release, falling back to the default branch.
+  if (params.has("path")) {
+    const ref =
+      params.get("branch") ||
+      params.get("ref") ||
+      params.get("commit") ||
+      params.get("release") ||
+      (await getDefaultBranch(repo, env)) ||
+      "main";
+    return proxyRawFile(repo, ref, params.get("path"));
   }
 
   // Atom feeds
@@ -220,6 +241,62 @@ async function handleAtomFeed(repo, type) {
     }
     return jsonResponse(
       { error: "Failed to fetch Atom feed.", details: error.message },
+      502,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Raw file resolution
+// ---------------------------------------------------------------------------
+
+// Fetches a single raw file from raw.githubusercontent.com and returns it with
+// CORS headers. Used to serve a repo's blueprint.json (or any small text/JSON
+// asset) cross-origin to the browser playground without inlining it in the URL.
+async function proxyRawFile(repo, ref, rawPath) {
+  const path = String(rawPath).replace(/^\/+/, "");
+  const url = `${GITHUB_RAW}/${repo}/${ref}/${path}`;
+
+  try {
+    // raw.githubusercontent.com serves directly (no redirect in practice), but
+    // validate any redirect hop against the GitHub host allowlist just in case.
+    const upstream = await fetchWithValidatedRedirects(
+      url,
+      { method: "GET", headers: { "User-Agent": "github-proxy-worker" } },
+      (candidate) =>
+        candidate.hostname === "raw.githubusercontent.com" ||
+        isGitHubDirectProxyUrl(candidate),
+    );
+
+    if (!upstream.ok) {
+      return jsonResponse(
+        {
+          error: "Upstream server returned an error.",
+          status: upstream.status,
+          statusText: upstream.statusText,
+        },
+        upstream.status === 404 ? 404 : 502,
+      );
+    }
+
+    const headers = new Headers();
+
+    applyCorsHeaders(headers);
+    headers.set(
+      "Content-Type",
+      path.toLowerCase().endsWith(".json")
+        ? "application/json; charset=utf-8"
+        : upstream.headers.get("Content-Type") || "text/plain; charset=utf-8",
+    );
+    headers.set("Cache-Control", "public, max-age=60");
+
+    return new Response(upstream.body, { status: 200, headers });
+  } catch (error) {
+    if (error instanceof RedirectBlockedError) {
+      return redirectBlockedResponse(error);
+    }
+    return jsonResponse(
+      { error: "Failed to fetch raw file.", details: error.message },
       502,
     );
   }
@@ -545,10 +622,27 @@ async function handleGenericProxy(targetUrl, request) {
     // Re-validate every redirect hop against the same generic-proxy allowlist
     // (and SSRF guard) that authorized the initial URL, so an allowlisted host
     // cannot 302 us into an internal or unsupported target.
+    //
+    // Nextcloud/ownCloud shares are the exception: GET /s/{token}/download
+    // 303-redirects to a signed DAV URL on the SAME host (e.g.
+    // /public.php/dav/files/{token}/), which does not match the public-share
+    // path shape. Authorize redirects that stay on the original share's host
+    // instead. The SSRF guard still runs for every hop.
+    //
+    // Dropbox shares redirect from www.dropbox.com to dl.dropboxusercontent.com
+    // (the CDN serving the actual file). Authorize that CDN host as a redirect
+    // target while still running the SSRF guard.
+    const isAuthorizedRedirect = isNextcloudShareUrl(parsedUrl)
+      ? (candidate) => candidate.hostname === parsedUrl.hostname
+      : isDropboxShareUrl(parsedUrl)
+        ? (candidate) =>
+            isSupportedGenericProxyUrl(candidate) || isDropboxCdnUrl(candidate)
+        : isSupportedGenericProxyUrl;
+
     const upstream = await fetchWithValidatedRedirects(
       parsedUrl.toString(),
       { method: "GET", headers: upstreamHeaders },
-      isSupportedGenericProxyUrl,
+      isAuthorizedRedirect,
     );
 
     if (!upstream.ok) {
@@ -662,9 +756,12 @@ function isSupportedGenericProxyUrl(url) {
     isFacturaScriptsPluginPage(url) ||
     isGitHubDirectProxyUrl(url) ||
     isGoogleDriveDirectFileUrl(url) ||
+    isNextcloudShareUrl(url) ||
+    isDropboxShareUrl(url) ||
     isOmekaOrgResourceUrl(url) ||
     isGitLabResourceUrl(url) ||
-    isJsDelivrResourceUrl(url)
+    isJsDelivrResourceUrl(url) ||
+    isMoodleLangpackUrl(url)
   ) {
     return true;
   }
@@ -702,8 +799,30 @@ function isAllowlistedProxyHost(url) {
     hostname === "facturascripts.com" ||
     hostname === "gitlab.com" ||
     hostname === "cdn.jsdelivr.net" ||
-    hostname === "data.jsdelivr.com"
+    hostname === "data.jsdelivr.com" ||
+    // Moodle language packs. `packaging.moodle.org` serves the actual ZIPs;
+    // `download.moodle.org/download.php/direct/langpack/...` 302-redirects to it
+    // (the redirect hop is re-validated, so both hosts must be allowlisted).
+    hostname === "packaging.moodle.org" ||
+    hostname === "download.moodle.org"
   );
+}
+
+// Moodle's `tool_langimport` first fetches the langpack index (`languages.md5`)
+// and then the per-language `<code>.zip`. The index file is not zip-like, so the
+// zip-only `isAllowlistedProxyHost` check would reject it. Authorize any
+// `/langpack/` path on the two Moodle hosts regardless of extension. The SSRF
+// guard in `isSupportedGenericProxyUrl` still runs first, and both hosts are
+// listed because `download.moodle.org` 302-redirects to `packaging.moodle.org`.
+function isMoodleLangpackUrl(url) {
+  const hostname = url.hostname.toLowerCase();
+  if (
+    hostname !== "download.moodle.org" &&
+    hostname !== "packaging.moodle.org"
+  ) {
+    return false;
+  }
+  return url.pathname.toLowerCase().includes("/langpack/");
 }
 
 // Reject hosts that resolve to private, loopback, or link-local addresses to
@@ -865,7 +984,26 @@ function isGoogleDriveDirectFileUrl(url) {
   return false;
 }
 
+// Nextcloud / ownCloud public share links live on arbitrary self-hosted
+// domains, so they cannot be matched by a fixed host allowlist. Authorize them
+// instead by their well-known public-share path shape:
+//   /s/{token}                  (share page)
+//   /s/{token}/download         (direct download; what eXeViewer requests)
+//   /index.php/s/{token}[/download]   (pretty-URLs-disabled instances)
+// The SSRF guard (isPrivateOrLocalHost) is still enforced for every host and
+// redirect hop, so this is not an open proxy into internal infrastructure.
+const NEXTCLOUD_SHARE_PATH =
+  /^(?:\/index\.php)?\/s\/[A-Za-z0-9._-]+(?:\/download)?\/?$/u;
+
+function isNextcloudShareUrl(url) {
+  return NEXTCLOUD_SHARE_PATH.test(url.pathname);
+}
+
 function normalizeSupportedGenericProxyUrl(url) {
+  if (isNextcloudShareUrl(url)) {
+    return normalizeNextcloudShareUrl(url);
+  }
+
   if (!isGoogleDriveDirectFileUrl(url)) {
     return url;
   }
@@ -894,6 +1032,21 @@ function normalizeSupportedGenericProxyUrl(url) {
 
   normalized.searchParams.set("id", fileId);
   normalized.searchParams.set("export", "download");
+
+  return normalized;
+}
+
+// Rewrite a bare Nextcloud/ownCloud share page (/s/{token}) to its direct
+// download endpoint (/s/{token}/download). A URL that already targets /download
+// (or carries a path/files query selecting a file inside a folder share) is
+// returned unchanged.
+function normalizeNextcloudShareUrl(url) {
+  if (url.pathname.replace(/\/$/u, "").endsWith("/download")) {
+    return url;
+  }
+
+  const normalized = new URL(url.toString());
+  normalized.pathname = `${normalized.pathname.replace(/\/$/u, "")}/download`;
 
   return normalized;
 }
@@ -1009,6 +1162,24 @@ function isFacturaScriptsPluginPage(url) {
     url.hostname.toLowerCase() === "facturascripts.com" &&
     /^\/plugins\/[^/]+\/?$/u.test(url.pathname)
   );
+}
+
+// Dropbox shared file links: /s/{hash}/{filename} (legacy) and
+// /scl/fi/{hash}/{filename} (newer secure format with rlkey+st params).
+// Both formats redirect to dl.dropboxusercontent.com for the actual download.
+function isDropboxShareUrl(url) {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "www.dropbox.com" && hostname !== "dropbox.com") {
+    return false;
+  }
+  return /^\/(?:s\/[A-Za-z0-9_-]+|scl\/fi\/[A-Za-z0-9_-]+)\//u.test(
+    url.pathname,
+  );
+}
+
+// Dropbox CDN — the redirect target after a successful share-link download.
+function isDropboxCdnUrl(url) {
+  return url.hostname.toLowerCase().endsWith(".dropboxusercontent.com");
 }
 
 function isOmekaOrgResourceUrl(url) {
@@ -1373,8 +1544,9 @@ function landingPageHtml(origin) {
         <span class="method">GET</span>
         <span class="endpoint-name">URL Proxy</span>
       </div>
-      <div class="endpoint-desc">Proxy supported ZIP, GitHub resource, Google Drive, or omeka.org / dev.omeka.org URLs with CORS headers.</div>
+      <div class="endpoint-desc">Proxy supported ZIP, GitHub resource, Google Drive, Nextcloud / ownCloud share, or omeka.org / dev.omeka.org URLs with CORS headers.</div>
       <div class="endpoint-desc">Drive accepts direct <code>/uc?id=...</code> links and shared <code>/file/d/{id}/view</code> links.</div>
+      <div class="endpoint-desc">Nextcloud / ownCloud accepts public share links <code>/s/{token}</code> and <code>/s/{token}/download</code> on any host.</div>
       <div class="url-box">${base}/?url=<span class="param">{full_url}</span></div>
     </div>
 


### PR DESCRIPTION
Re-syncs the **SYNCED MIRROR** `scripts/zip-proxy-worker.js` with the canonical
`moodle-playground/scripts/github-proxy-worker.js`.

## Primary change
Moodle **language-pack** support: allowlist `download.moodle.org` + `packaging.moodle.org` and
authorize `/langpack/` paths (incl. the non-zip index `languages.md5`) so Moodle's language
installer works through the proxy. See moodle-playground#135 / ADR-0006.

## Also re-synced (drift since last sync)
The mirror had fallen behind the canonical; this also brings: raw-file `?path=` mode,
Nextcloud/Dropbox public-share links, GitLab and jsDelivr support. These are additive proxy
allowances — no existing behavior is removed.

This matches the **deployed** `zip-proxy` worker (re-deployed from the canonical). The
`SYNCED MIRROR` header is preserved; the body is otherwise byte-identical to the canonical.