### PR TITLE
fix(sw): buffer request bodies so Firefox keeps them (form POSTs/login)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -235,28 +235,17 @@ async function resolveScopedRequest(event, url) {
     };
 }
 
-async function serializeRequest(request) {
+// Build the serialized request posted to the PHP worker. The body is the
+// already-buffered ArrayBuffer captured synchronously in the fetch handler (see
+// the comment there): forwarding the original request's stream instead would
+// throw in Firefox, which neuters event.request.body once the handler yields.
+async function buildForwardedRequest(originalRequest, forwardedUrl, bufferedBody) {
   return {
-    url: request.url,
-    method: request.method,
-    headers: Object.fromEntries(request.headers.entries()),
-    body: ["GET", "HEAD"].includes(request.method) ? null : await request.clone().arrayBuffer(),
-  };
-}
-
-function buildPhpRequest(originalRequest, forwardedUrl) {
-  const init = {
+    url: forwardedUrl.toString(),
     method: originalRequest.method,
-    headers: new Headers(originalRequest.headers),
-    redirect: "follow",
+    headers: Object.fromEntries(new Headers(originalRequest.headers).entries()),
+    body: bufferedBody ? await bufferedBody : null,
   };
-
-  if (!["GET", "HEAD"].includes(originalRequest.method)) {
-    init.body = originalRequest.body;
-    init.duplex = "half";
-  }
-
-  return new Request(forwardedUrl.toString(), init);
 }
 
 function rewriteScopedLocation(response, { origin, scopeId, runtimeId }) {
@@ -394,11 +383,11 @@ function buildScopedUrl(url, { scopeId, runtimeId, requestPath }) {
   return new URL(`${scopedPath}`, url.origin);
 }
 
-function forwardToPhpWorker({ request, runtimeId, scopeId }) {
+function forwardToPhpWorker({ serializedRequest, runtimeId, scopeId }) {
   const bridge = ensureBridge(scopeId);
   const id = createWorkerRequestId();
 
-  return new Promise(async (resolve) => {
+  return new Promise((resolve) => {
     const timeoutId = self.setTimeout(() => {
       pending.delete(id);
       resolve(buildErrorResponse("PHP worker bridge timed out.", 504));
@@ -409,7 +398,7 @@ function forwardToPhpWorker({ request, runtimeId, scopeId }) {
     bridge.postMessage({
       kind: "http-request",
       id,
-      request: await serializeRequest(request),
+      request: serializedRequest,
     });
   });
 }
@@ -443,6 +432,17 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
+  // Firefox neuters event.request.body once this handler yields to the event
+  // loop, so buffer the body synchronously now — before any await — for the
+  // methods that carry one. Reading it later (after the resolveScopedRequest()
+  // awaits) throws in Firefox and makes the whole handler reject ("A
+  // ServiceWorker intercepted the request and encountered an unexpected
+  // error"), which broke every POST/PUT form submission. The buffered bytes
+  // are forwarded to the PHP worker in place of the stream. Cloning leaves
+  // event.request intact for the pass-through fetch() branches.
+  const bufferedBody = ["GET", "HEAD"].includes(event.request.method)
+    ? null
+    : event.request.clone().arrayBuffer().catch(() => null);
   event.respondWith((async () => {
     const url = new URL(event.request.url);
     if (url.origin !== self.location.origin) {
@@ -496,7 +496,7 @@ self.addEventListener("fetch", (event) => {
     const forwardedUrl = new URL(requestPath, `${url.origin}/`);
 
     const response = await forwardToPhpWorker({
-      request: buildPhpRequest(event.request, forwardedUrl),
+      serializedRequest: await buildForwardedRequest(event.request, forwardedUrl, bufferedBody),
       runtimeId,
       scopeId,
     }).catch((error) => buildErrorResponse(String(error?.stack || error?.message || error)));


### PR DESCRIPTION
## Problem

On Firefox, non-GET requests that depend on their body — admin form `POST`s, including **login** (which carries the CSRF token + credentials) — reached PHP **empty**, so they failed. Chrome was unaffected.

## Root cause

Firefox neuters `event.request.body` once the service-worker `fetch` handler yields to the event loop. The worker bridge only read the body deep inside `forwardToPhpWorker` → `serializeRequest` — i.e. **after** `await resolveScopedRequest()` — and built a stream-bodied `new Request({ body: …, duplex: "half" })`. By then Firefox had discarded the body.

## Fix

Buffer the body **synchronously** at the very top of the `fetch` handler — before any `await` — and forward the buffered bytes:

```js
const bufferedBody = ["GET", "HEAD"].includes(event.request.method)
  ? null
  : event.request.clone().arrayBuffer().catch(() => null);
```

`buildPhpRequest` + `serializeRequest` are replaced by a single `buildForwardedRequest(originalRequest, forwardedUrl, bufferedBody)` that posts the already-buffered `ArrayBuffer` to the worker. Chrome behaviour is unchanged (the worker already received an `ArrayBuffer` body).

## Verification

Before/after with **Playwright Firefox** (logout → POST login with CSRF + credentials → check admin access):

| | old SW | this fix |
|---|---|---|
| `loggedInAfter` | **false** (body discarded) | **true** |

`make lint`, `make test` (107 unit), `npm run test:e2e` (5 Chrome e2e) pass. Diff is `sw.js` only. Same one-file change as ateeducacion/nextcloud-playground#24.