### PR TITLE
fix(sw): cache-bust the SW + php-worker by per-build BUILD_VERSION

### DIFF
--- a/src/remote/main.js
+++ b/src/remote/main.js
@@ -1,3 +1,4 @@
+import { BUILD_VERSION } from "../generated/build-version.js";
 import { loadActiveBlueprint } from "../shared/blueprint.js";
 import { loadPlaygroundConfig } from "../shared/config.js";
 import { resolveRuntimeConfig } from "../shared/omeka-versions.js";
@@ -52,7 +53,7 @@ async function registerRuntimeServiceWorker(scopeId, runtimeId, config) {
   }
 
   const swUrl = new URL("../../sw.js", import.meta.url);
-  swUrl.searchParams.set("v", config.bundleVersion);
+  swUrl.searchParams.set("v", BUILD_VERSION);
   swUrl.searchParams.set("scope", scopeId);
   swUrl.searchParams.set("runtime", runtimeId);
 
@@ -250,6 +251,9 @@ async function bootstrapRemote() {
       "../../dist/php-worker.bundle.js",
       import.meta.url,
     );
+    // Cache-bust the worker bundle (fixed filename, not SW-cached) so a redeploy
+    // never serves a stale runtime from the browser HTTP cache.
+    workerUrl.searchParams.set("v", BUILD_VERSION);
     workerUrl.searchParams.set("scope", scopeId);
     workerUrl.searchParams.set("runtime", runtime.id);
     phpWorker = new Worker(workerUrl, { type: "module" });

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -1,3 +1,4 @@
+import { BUILD_VERSION } from "../generated/build-version.js";
 import {
   buildDefaultBlueprint,
   clearActiveBlueprint,
@@ -109,7 +110,9 @@ async function ensureRuntimeServiceWorker() {
   }
 
   const swUrl = new URL("../../sw.js", import.meta.url);
-  swUrl.searchParams.set("v", config.bundleVersion);
+  // Cache-bust the SW by the per-build worker-bundle hash so a redeploy is
+  // always picked up (the old static config.bundleVersion was manual).
+  swUrl.searchParams.set("v", BUILD_VERSION);
   swUrl.searchParams.set("scope", scopeId);
   swUrl.searchParams.set("runtime", currentRuntimeId);
 


### PR DESCRIPTION
## Problem

When redeploying from `main`, two things could keep returning users on stale code:

1. **The SW** was registered as `sw.js?v=${config.bundleVersion}` — a **manual** static string in `playground.config.json` (currently `0.1.0`). If you forget to bump it, the `?v=` never changes.
2. **The php-worker** (`dist/php-worker.bundle.js` — the actual WASM runtime code) was loaded with **no version** (`new Worker(...)` in `src/remote/main.js`) and is **not** SW-cached (the SW only caches `/dist/*.wasm|*.so`). So it relies solely on the browser HTTP cache → a returning user **reloading the same tab** after a deploy could keep the **old worker**.

(The lifecycle bits were already fine: `updateViaCache: "none"`, `registration.update()`, `skipWaiting()`, `clients.claim()`, cache purge on activate.)

## Fix

Reuse the per-build **`BUILD_VERSION`** already generated in `src/generated/build-version.js` (a content hash of `dist/php-worker.bundle.js`, written by `scripts/esbuild.worker.mjs`) as the `?v=` token for **both**:

- the SW registration URL (`src/shell/main.js` + `src/remote/main.js`), replacing the manual `config.bundleVersion`;
- the `new Worker(dist/php-worker.bundle.js)` URL (`src/remote/main.js`).

A worker/WASM change now changes `BUILD_VERSION` → both URLs change → the browser fetches a fresh SW **and** a fresh worker, and the old `/dist` cache is purged on activate. Shell-only deploys leave `BUILD_VERSION` unchanged, so the (heavy) worker/WASM aren't needlessly re-downloaded. `config.bundleVersion` is left intact for any other use.

Content-hash (not a per-deploy timestamp) is deliberate: it busts **exactly** when the worker/WASM change — which is when it matters — and avoids re-downloading ~20 MB of WASM on deploys that only touch the shell. `sw.js` byte changes are detected independently.

## Verification

In-browser (Playwright): the SW registers as `sw.js?v=1963a88add98&…` and the `php-worker.bundle.js` request carries `?v=1963a88add98&…`. `make lint`, `make test` (107), `npm run test:e2e` (5) pass. Diff is 2 files.

moodle-playground already has an equivalent (stronger) mechanism, so it needs no change.