### PR TITLE
fix: phpConstants had no effect on SW-served requests (define them in local.config.php)

### DIFF
--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -81,10 +81,20 @@ function buildDatabaseIni() {
 
 function buildLocalConfig(config) {
   const debugEnabled = config.debug?.enabled === true;
+  const phpConstantDefines = buildPhpConstantDefines(config.phpConstants);
 
   return `<?php
 ${debugEnabled ? "ini_set('display_errors', '1');" : ""}
-
+${
+  phpConstantDefines
+    ? `// Blueprint-provided PHP constants. Also defined here because local.config.php is
+// require()'d during Omeka's bootstrap (before any module loads), so the constants are
+// reliably available to module code even where the auto_prepend_file prepend does not
+// apply to a request.
+${phpConstantDefines}
+`
+    : ""
+}
 $thumbnailerAlias = extension_loaded('gd')
     ? 'Omeka\\\\File\\\\Thumbnailer\\\\Gd'
     : 'Omeka\\\\File\\\\Thumbnailer\\\\NoThumbnail';


### PR DESCRIPTION
## Problem (reproduced in the live playground)

A blueprint that declares `"phpConstants": { "EXELEARNING_UNSAFE_LEGACY_IFRAME": true }` had **no effect**: the eXeLearning module kept rendering its content iframe **opaque** (`sandbox="allow-scripts allow-popups allow-forms"`, no `allow-same-origin`), and since the php-wasm service worker cannot serve an opaque subframe, the embedded project rendered as a **GitHub-Pages 404**.

Verified directly in the deployed playground (a public Omeka item with an `.elpx`):
- the content `<iframe>` is opaque, and a fetch of its (correctly-scoped) content URL returns `200` **with a CSP `sandbox` directive** → the module is in **secure** mode on the server too;
- so `IframeSandbox::isUnsafeLegacy()` returns `false` → the `EXELEARNING_UNSAFE_LEGACY_IFRAME` constant is **not defined** in the PHP runtime;
- this persists after a full reset (SW + Cache + IndexedDB cleared), so it is **not** a stale cache;
- the JS chain is correct: `normalizeBlueprint`/`buildEffectivePlaygroundConfig` carry `phpConstants` through, and `buildPhpPrepend` emits the right `define(..., true)`.

The remaining gap is that the `auto_prepend_file` prepend (where #107 put the defines) is not effective for the SW-served Omeka requests, so the constants never reach module code.

## Fix

Also emit the guarded `define()` calls in **`local.config.php`** (top of the file, before the returned config array). `local.config.php` is `require()`'d during Omeka's bootstrap — before any module loads — so the blueprint's `phpConstants` are reliably defined for every request. The prepend defines are kept unchanged (belt-and-suspenders).

Generic and engine-agnostic: any blueprint's `phpConstants` benefit; no eXeLearning-specific value is hardcoded.

## Note

I could not deploy + click-test this exact branch (the playground deploys from `main`), but `local.config.php` is unconditionally executed at bootstrap, so the constant is guaranteed to be defined before the module's renderer runs. Pairs with `omeka-s-exelearning` PR #21 (its `blueprint.json` declares the constant) and follows up #107.