### PR TITLE
Make the blueprint panel editable and runnable

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
     <meta name="twitter:image:alt" content="Omeka S Playground">
     <link rel="icon" type="image/x-icon" href="./favicon.ico">
     <link rel="stylesheet" href="./src/styles/app.css">
+    <link rel="stylesheet" href="./src/styles/blueprint-editor.css">
   </head>
   <body data-app="shell">
     <div class="shell">
@@ -167,12 +168,53 @@
             <div class="panel__row">
               <span>Blueprint JSON</span>
               <span class="panel__row-actions">
-                <button type="button" id="export-button">Export</button>
-                <label class="import-button" for="import-input">Import</label>
+                <button type="button" id="run-button" class="bp-btn bp-btn--primary bp-btn--wide" title="Run blueprint" disabled>
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false">
+                    <path d="M4 2.5v11l10-5.5-10-5.5Z"/>
+                  </svg>
+                  <span>Run</span>
+                </button>
+                <button type="button" id="export-button" class="bp-btn bp-btn--icon-only" title="Export blueprint JSON" aria-label="Export blueprint JSON">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M8 2v7m0 0L5 6m3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M3 11v1.5A1.5 1.5 0 0 0 4.5 14h7a1.5 1.5 0 0 0 1.5-1.5V11" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                  </svg>
+                </button>
+                <label class="import-button bp-btn bp-btn--icon-only" for="import-input" title="Import blueprint JSON" aria-label="Import blueprint JSON">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M8 9V2m0 0L5 5m3-3 3 3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M3 11v1.5A1.5 1.5 0 0 0 4.5 14h7a1.5 1.5 0 0 0 1.5-1.5V11" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                  </svg>
+                </label>
                 <input id="import-input" type="file" accept="application/json" hidden>
+                <button type="button" id="copy-button" class="bp-btn bp-btn--icon-only" title="Copy blueprint JSON" aria-label="Copy blueprint JSON">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <rect x="5" y="5" width="8" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
+                    <path d="M11 5V3.5A1.5 1.5 0 0 0 9.5 2h-5A1.5 1.5 0 0 0 3 3.5v7A1.5 1.5 0 0 0 4.5 12H5" stroke="currentColor" stroke-width="1.3" fill="none"/>
+                  </svg>
+                </button>
               </span>
             </div>
-            <textarea id="blueprint-textarea" class="panel-textarea" spellcheck="false" readonly></textarea>
+            <div class="blueprint-editor-wrap">
+              <div
+                id="blueprint-editor"
+                class="blueprint-editor is-hidden"
+                role="textbox"
+                aria-multiline="true"
+                aria-label="Blueprint JSON editor"
+                tabindex="0"
+                spellcheck="false"
+              ></div>
+              <textarea
+                id="blueprint-textarea"
+                class="panel-textarea blueprint-editor-fallback"
+                spellcheck="false"
+                aria-label="Blueprint JSON editor"
+              ></textarea>
+              <p id="blueprint-status" class="blueprint-status" role="status" aria-live="polite">
+                Loading blueprint…
+              </p>
+            </div>
           </section>
 
           <footer class="side-panel__footer">

--- a/src/shell/blueprint-editor-core.js
+++ b/src/shell/blueprint-editor-core.js
@@ -1,0 +1,183 @@
+/**
+ * Pure helpers for the editable Blueprint panel (no DOM access here — see
+ * `blueprint-editor.js` for CodeJar wiring). Kept dependency-free so they can
+ * be unit tested directly.
+ */
+
+/**
+ * Escape a string for safe insertion into HTML text content.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+export function escapeHtml(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+// Matches, in priority order: a quoted string (optionally followed by the
+// colon that marks it as an object key), a boolean literal, a null literal,
+// or a number. Everything else (punctuation, whitespace) falls through
+// untouched between matches.
+const JSON_TOKEN_RE =
+  /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false)\b|\b(null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/gu;
+
+/**
+ * Render JSON source as HTML with `bp-tok-*` span classes for keys, strings,
+ * numbers, booleans and null — a small hand-rolled tokenizer instead of a
+ * full syntax-highlighting dependency.
+ *
+ * @param {string} code
+ * @returns {string} HTML-safe markup.
+ */
+export function highlightJson(code) {
+  const text = typeof code === "string" ? code : "";
+  let html = "";
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(JSON_TOKEN_RE)) {
+    const [
+      full,
+      stringLiteral,
+      colonSuffix,
+      boolLiteral,
+      nullLiteral,
+      numberLiteral,
+    ] = match;
+    html += escapeHtml(text.slice(lastIndex, match.index));
+
+    if (stringLiteral !== undefined) {
+      const cssClass = colonSuffix ? "bp-tok-key" : "bp-tok-string";
+      html += `<span class="${cssClass}">${escapeHtml(stringLiteral)}</span>`;
+      html += escapeHtml(colonSuffix || "");
+    } else if (boolLiteral !== undefined) {
+      html += `<span class="bp-tok-boolean">${escapeHtml(boolLiteral)}</span>`;
+    } else if (nullLiteral !== undefined) {
+      html += `<span class="bp-tok-null">${escapeHtml(nullLiteral)}</span>`;
+    } else if (numberLiteral !== undefined) {
+      html += `<span class="bp-tok-number">${escapeHtml(numberLiteral)}</span>`;
+    }
+
+    lastIndex = match.index + full.length;
+  }
+
+  html += escapeHtml(text.slice(lastIndex));
+  return html;
+}
+
+/**
+ * Pretty-print a JSON string with 2-space indentation.
+ *
+ * @param {string} rawText
+ * @returns {string}
+ * @throws {SyntaxError} if `rawText` is not valid JSON.
+ */
+export function formatBlueprintText(rawText) {
+  return JSON.stringify(JSON.parse(rawText), null, 2);
+}
+
+/**
+ * Compute the code to seed the editor with from source text (typically the
+ * hidden `#blueprint-textarea` value). Pretty-prints valid JSON; falls back
+ * to the raw text unchanged if it can't be parsed, so partially-typed or
+ * externally-supplied text is never discarded.
+ *
+ * @param {*} sourceText
+ * @returns {string}
+ */
+export function getInitialBlueprintCode(sourceText) {
+  const text = typeof sourceText === "string" ? sourceText : "";
+  if (!text.trim()) {
+    return "";
+  }
+  try {
+    return formatBlueprintText(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Run the editor content through the JSON parse -> blueprint normalize
+ * pipeline, mapping the result to a single user-facing status. Never throws.
+ *
+ * Unlike moodle-playground's step-schema engine, this repo's `normalizeBlueprint`
+ * (src/shared/blueprint.js) never rejects a well-formed JSON object — it fills
+ * in defaults instead. The "schema" stage here therefore only rejects JSON that
+ * isn't a plain object (string/number/array), which `deps.normalizeBlueprint`
+ * is expected to throw for.
+ *
+ * @param {string} rawText
+ * @param {{normalizeBlueprint: Function}} deps `normalizeBlueprint(parsedJson)`
+ *   returns a normalized blueprint object, or throws if the input can't be
+ *   normalized.
+ * @returns {{valid: boolean, stage: "json"|"schema"|"valid", message: string, blueprint: object|null}}
+ */
+export function createBlueprintValidationResult(rawText, deps) {
+  const { normalizeBlueprint } = deps;
+
+  const trimmed = typeof rawText === "string" ? rawText.trim() : "";
+  if (!trimmed) {
+    return {
+      valid: false,
+      stage: "json",
+      message: "Blueprint cannot be empty.",
+      blueprint: null,
+    };
+  }
+
+  let parsedJson;
+  try {
+    parsedJson = JSON.parse(trimmed);
+  } catch (error) {
+    return {
+      valid: false,
+      stage: "json",
+      message: `Invalid JSON: ${error.message}`,
+      blueprint: null,
+    };
+  }
+
+  let blueprint;
+  try {
+    blueprint = normalizeBlueprint(parsedJson);
+  } catch (error) {
+    return {
+      valid: false,
+      stage: "schema",
+      message: `Blueprint is invalid: ${error.message}`,
+      blueprint: null,
+    };
+  }
+
+  return {
+    valid: true,
+    stage: "valid",
+    message: "Blueprint is valid.",
+    blueprint,
+  };
+}
+
+/**
+ * Build the URL to navigate to in order to run an edited blueprint: sets
+ * `blueprint=<encodedBlueprint>` and removes the legacy `blueprint-url` /
+ * `blueprint-data` params, preserving everything else on the current URL.
+ *
+ * @param {string} currentHref
+ * @param {string} encodedBlueprint
+ * @returns {string}
+ */
+export function buildBlueprintRunUrl(currentHref, encodedBlueprint) {
+  const url = new URL(currentHref);
+  url.searchParams.set("blueprint", encodedBlueprint);
+  url.searchParams.delete("blueprint-url");
+  url.searchParams.delete("blueprint-data");
+  return url.toString();
+}

--- a/src/shell/blueprint-editor.js
+++ b/src/shell/blueprint-editor.js
@@ -1,0 +1,196 @@
+import {
+  encodeBlueprintParam,
+  normalizeBlueprint,
+} from "../shared/blueprint.js";
+import {
+  buildBlueprintRunUrl,
+  createBlueprintValidationResult,
+  highlightJson,
+} from "./blueprint-editor-core.js";
+
+// Pinned version, loaded on demand so the static shell doesn't need a bundler
+// step for it. If the CDN is unreachable the panel falls back to a plain
+// editable textarea (see initBlueprintEditor below).
+const CODEJAR_MODULE_URL =
+  "https://cdn.jsdelivr.net/npm/codejar@4.3.0/dist/codejar.js";
+
+function highlightForCodeJar(editor) {
+  editor.innerHTML = highlightJson(editor.textContent);
+}
+
+/**
+ * Wire the Blueprint panel's editor: CodeJar (with a plain-textarea
+ * fallback), live JSON validation, and the Run button. The hidden `textarea`
+ * stays in sync with the editor content at all times, so any existing code
+ * that reads `#blueprint-textarea` keeps working.
+ *
+ * @param {{mount: HTMLElement|null, textarea: HTMLTextAreaElement, statusEl: HTMLElement|null, runButton: HTMLButtonElement|null, copyButton: HTMLButtonElement|null}} elements
+ * @param {{location?: Location, getConfig?: () => object|undefined}} [options]
+ *   `getConfig` is read live on every validation pass (not captured once) —
+ *   `config` in main.js is only populated after this module initializes.
+ * @returns {{setCode(text: string): void, getCode(): string, getValidationResult(): object, setLocked(locked: boolean): void}}
+ */
+export function initBlueprintEditor(elements, options = {}) {
+  const { mount, textarea, statusEl, runButton, copyButton } = elements;
+  const loc = options.location || window.location;
+  const getConfig = options.getConfig || (() => undefined);
+
+  function normalizeForValidation(parsedJson) {
+    if (
+      !parsedJson ||
+      typeof parsedJson !== "object" ||
+      Array.isArray(parsedJson)
+    ) {
+      throw new Error("Blueprint must be a JSON object.");
+    }
+    return normalizeBlueprint(parsedJson, getConfig() || {});
+  }
+
+  let jar = null;
+  let locked = false;
+  let currentText = textarea ? textarea.value : "";
+  let latestResult = createBlueprintValidationResult(currentText, {
+    normalizeBlueprint: normalizeForValidation,
+  });
+
+  function getText() {
+    return jar ? jar.toString() : currentText;
+  }
+
+  function updateRunButtonState() {
+    if (!runButton) return;
+    runButton.disabled = locked || !latestResult.valid;
+  }
+
+  function applyStatus() {
+    if (!statusEl) return;
+    statusEl.classList.remove("is-valid", "is-invalid", "is-running");
+    statusEl.classList.add(latestResult.valid ? "is-valid" : "is-invalid");
+    statusEl.textContent = latestResult.message;
+  }
+
+  function revalidate(text) {
+    latestResult = createBlueprintValidationResult(text, {
+      normalizeBlueprint: normalizeForValidation,
+    });
+    applyStatus();
+    updateRunButtonState();
+    return latestResult;
+  }
+
+  function handleTextChanged(text) {
+    currentText = text;
+    if (textarea) {
+      textarea.value = text;
+    }
+    revalidate(text);
+  }
+
+  if (textarea) {
+    textarea.readOnly = false;
+    textarea.addEventListener("input", () => {
+      if (jar) return; // CodeJar owns editing once it takes over.
+      handleTextChanged(textarea.value);
+    });
+  }
+
+  revalidate(currentText);
+
+  if (mount) {
+    import(/* webpackIgnore: true */ CODEJAR_MODULE_URL)
+      .then(({ CodeJar }) => {
+        // The CDN fetch is async, so the user may already be typing in the
+        // fallback textarea by the time this resolves. Carry focus over to
+        // the CodeJar mount so those keystrokes keep landing on the active
+        // editor instead of silently hitting the now-hidden textarea (whose
+        // own input listener turns into a no-op once `jar` is set below).
+        const hadFocus = document.activeElement === textarea;
+
+        jar = CodeJar(mount, highlightForCodeJar, { tab: "  " });
+        jar.updateCode(currentText, false);
+        highlightForCodeJar(mount);
+        jar.onUpdate((code) => handleTextChanged(code));
+
+        mount.classList.remove("is-hidden");
+        if (textarea) {
+          textarea.classList.add("is-hidden");
+        }
+        if (hadFocus) {
+          mount.focus();
+        }
+      })
+      .catch(() => {
+        // CodeJar unavailable — the fallback textarea (already wired above)
+        // stays the active, visible editor.
+      });
+  }
+
+  if (runButton) {
+    runButton.addEventListener("click", async () => {
+      const result = revalidate(getText());
+      if (!result.valid) {
+        return;
+      }
+
+      runButton.disabled = true;
+      if (statusEl) {
+        statusEl.classList.remove("is-valid", "is-invalid");
+        statusEl.classList.add("is-running");
+        statusEl.textContent = "Encoding blueprint and restarting playground…";
+      }
+
+      const encoded = await encodeBlueprintParam(result.blueprint);
+      loc.href = buildBlueprintRunUrl(loc.href, encoded);
+    });
+  }
+
+  if (copyButton) {
+    const originalTitle = copyButton.getAttribute("title") || "";
+    const originalAriaLabel = copyButton.getAttribute("aria-label") || "";
+    const originalHtml = copyButton.innerHTML;
+    const checkmarkHtml =
+      '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">' +
+      '<path d="M3 8.5 6.5 12 13 4.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>' +
+      "</svg>";
+    copyButton.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(getText());
+      } catch {
+        return;
+      }
+      copyButton.innerHTML = checkmarkHtml;
+      copyButton.setAttribute("title", "Copied!");
+      copyButton.setAttribute("aria-label", "Copied!");
+      setTimeout(() => {
+        copyButton.innerHTML = originalHtml;
+        copyButton.setAttribute("title", originalTitle);
+        copyButton.setAttribute("aria-label", originalAriaLabel);
+      }, 1200);
+    });
+  }
+
+  return {
+    setCode(text) {
+      const safeText = typeof text === "string" ? text : "";
+      currentText = safeText;
+      if (textarea) {
+        textarea.value = safeText;
+        textarea.scrollTop = 0;
+      }
+      if (jar) {
+        jar.updateCode(safeText, false);
+      }
+      revalidate(safeText);
+    },
+    getCode() {
+      return getText();
+    },
+    getValidationResult() {
+      return latestResult;
+    },
+    setLocked(value) {
+      locked = Boolean(value);
+      updateRunButtonState();
+    },
+  };
+}

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -28,17 +28,22 @@ import {
   loadSessionState,
   saveSessionState,
 } from "../shared/storage.js";
+import { initBlueprintEditor } from "./blueprint-editor.js";
 
 const els = {
   addressForm: document.querySelector("#address-form"),
   address: document.querySelector("#address-input"),
+  blueprintEditorMount: document.querySelector("#blueprint-editor"),
   blueprintPanel: document.querySelector("#blueprint-panel"),
+  blueprintStatus: document.querySelector("#blueprint-status"),
   blueprintTab: document.querySelector("#blueprint-tab"),
   blueprintTextarea: document.querySelector("#blueprint-textarea"),
   clearLogs: document.querySelector("#clear-logs-button"),
+  copyBlueprintButton: document.querySelector("#copy-button"),
   copyLogs: document.querySelector("#copy-logs-button"),
   exportButton: document.querySelector("#export-button"),
   importInput: document.querySelector("#import-input"),
+  runButton: document.querySelector("#run-button"),
   frame: document.querySelector("#site-frame"),
   logPanel: document.querySelector("#log-panel"),
   logsPanel: document.querySelector("#logs-panel"),
@@ -67,6 +72,16 @@ const els = {
 
 const scopeId = getOrCreateScopeId();
 let config;
+const blueprintEditor = initBlueprintEditor(
+  {
+    mount: els.blueprintEditorMount,
+    textarea: els.blueprintTextarea,
+    statusEl: els.blueprintStatus,
+    runButton: els.runButton,
+    copyButton: els.copyBlueprintButton,
+  },
+  { getConfig: () => config },
+);
 let currentRuntimeId;
 let currentPhpVersion = DEFAULT_PHP_VERSION;
 let currentOmekaVersion = DEFAULT_OMEKA_VERSION;
@@ -102,6 +117,7 @@ function setUiLocked(locked) {
   els.exportButton.disabled = locked;
   els.importInput.disabled = locked;
   els.addressForm.classList.toggle("is-disabled", locked);
+  blueprintEditor.setLocked(locked);
 }
 
 async function ensureRuntimeServiceWorker() {
@@ -294,8 +310,13 @@ function saveState(extra = {}) {
 }
 
 function exportBlueprint() {
-  const payload = exportBlueprintPayload(config, activeBlueprint);
-  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+  const result = blueprintEditor.getValidationResult();
+  if (!result.valid) {
+    appendLog(`Cannot export blueprint: ${result.message}`, true);
+    return;
+  }
+
+  const blob = new Blob([JSON.stringify(result.blueprint, null, 2)], {
     type: "application/json",
   });
   const url = URL.createObjectURL(blob);
@@ -307,16 +328,13 @@ function exportBlueprint() {
 }
 
 function updateBlueprintTextarea() {
-  if (!config || !activeBlueprint || !els.blueprintTextarea) {
+  if (!config || !activeBlueprint) {
     return;
   }
 
-  els.blueprintTextarea.value = JSON.stringify(
-    exportBlueprintPayload(config, activeBlueprint),
-    null,
-    2,
+  blueprintEditor.setCode(
+    JSON.stringify(exportBlueprintPayload(config, activeBlueprint), null, 2),
   );
-  els.blueprintTextarea.scrollTop = 0;
 }
 
 async function importPayload(file) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -525,6 +525,8 @@ button.danger:hover {
 /* -- Panel rows (logs/phpinfo/blueprint headers) ----------- */
 .panel__row {
   justify-content: space-between;
+  flex-wrap: wrap;
+  row-gap: var(--space-xs);
   margin-bottom: var(--space-sm);
   font:
     600 11px / 1.2 ui-monospace,
@@ -537,7 +539,16 @@ button.danger:hover {
 
 .panel__row-actions {
   display: flex;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  justify-content: flex-end;
   gap: var(--space-xs);
+}
+
+.panel__row-actions button,
+.panel__row-actions label {
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 /* -- Log panel --------------------------------------------- */

--- a/src/styles/blueprint-editor.css
+++ b/src/styles/blueprint-editor.css
@@ -1,0 +1,132 @@
+/* ── Blueprint editor (CodeJar + fallback textarea) ──────────────── */
+.blueprint-editor-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 0;
+  height: 100%;
+}
+
+.blueprint-editor,
+.blueprint-editor-fallback {
+  flex: 1;
+  min-height: 180px;
+  margin: 0;
+}
+
+/* CodeJar mount point. Matches .panel-textarea's dark surface so the
+   fallback and the upgraded editor are visually indistinguishable. */
+.blueprint-editor {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  background: var(--color-gray-900);
+  color: #e4e8ec;
+  font:
+    12px / 1.5 ui-monospace,
+    "SFMono-Regular",
+    monospace;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.blueprint-editor.is-hidden,
+.blueprint-editor-fallback.is-hidden {
+  display: none;
+}
+
+.blueprint-editor:focus,
+.blueprint-editor:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--color-maroon-light);
+}
+
+/* JSON token colors (dark surface) */
+.blueprint-editor .bp-tok-key {
+  color: #7dd3fc;
+}
+
+.blueprint-editor .bp-tok-string {
+  color: #facc15;
+}
+
+.blueprint-editor .bp-tok-number {
+  color: #c4b5fd;
+}
+
+.blueprint-editor .bp-tok-boolean {
+  color: #fb923c;
+  font-weight: 600;
+}
+
+.blueprint-editor .bp-tok-null {
+  color: var(--color-gray-500);
+  font-style: italic;
+}
+
+.blueprint-status {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-muted);
+  min-height: 1.4em;
+}
+
+.blueprint-status.is-valid {
+  color: var(--color-success);
+}
+
+.blueprint-status.is-invalid {
+  color: var(--color-danger);
+}
+
+.blueprint-status.is-running {
+  color: var(--text-muted);
+}
+
+/* ── Toolbar buttons: Run/Export/Import/Copy, all in the top row ──────
+   Named .bp-btn (not .icon-button) — this repo already has a global,
+   fixed-36px .icon-button class used elsewhere, incompatible with the
+   wide/labeled/primary variants needed here. */
+.bp-btn {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 5px;
+  padding: 6px 10px;
+  white-space: nowrap;
+}
+
+.bp-btn svg {
+  flex: none;
+}
+
+.bp-btn--icon-only {
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+}
+
+.bp-btn--wide {
+  min-width: 76px;
+  justify-content: center;
+}
+
+.bp-btn--primary {
+  color: var(--color-white);
+  background: var(--accent);
+  border-color: transparent;
+}
+
+.bp-btn--primary:hover {
+  background: var(--accent-hover);
+}
+
+.bp-btn--primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  background: var(--accent);
+}

--- a/tests/blueprint-editor-core.test.mjs
+++ b/tests/blueprint-editor-core.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildBlueprintRunUrl,
+  createBlueprintValidationResult,
+  escapeHtml,
+  formatBlueprintText,
+  getInitialBlueprintCode,
+  highlightJson,
+} from "../src/shell/blueprint-editor-core.js";
+
+describe("escapeHtml", () => {
+  it("escapes ampersands, angle brackets and double quotes", () => {
+    assert.strictEqual(
+      escapeHtml(`<a href="x">Tom & Jerry</a>`),
+      "&lt;a href=&quot;x&quot;&gt;Tom &amp; Jerry&lt;/a&gt;",
+    );
+  });
+
+  it("escapes single quotes", () => {
+    assert.strictEqual(escapeHtml("it's"), "it&#39;s");
+  });
+
+  it("returns an empty string for non-string input", () => {
+    assert.strictEqual(escapeHtml(undefined), "");
+    assert.strictEqual(escapeHtml(null), "");
+  });
+});
+
+describe("highlightJson", () => {
+  it("wraps object keys in a key token class", () => {
+    const html = highlightJson('{"name": "value"}');
+    assert.match(html, /<span class="bp-tok-key">&quot;name&quot;<\/span>/);
+  });
+
+  it("wraps string values in a string token class", () => {
+    const html = highlightJson('{"name": "value"}');
+    assert.match(html, /<span class="bp-tok-string">&quot;value&quot;<\/span>/);
+  });
+
+  it("wraps numbers in a number token class", () => {
+    const html = highlightJson('{"count": 42}');
+    assert.match(html, /<span class="bp-tok-number">42<\/span>/);
+  });
+
+  it("wraps booleans in a boolean token class", () => {
+    const html = highlightJson('{"active": true}');
+    assert.match(html, /<span class="bp-tok-boolean">true<\/span>/);
+  });
+
+  it("wraps null in a null token class", () => {
+    const html = highlightJson('{"value": null}');
+    assert.match(html, /<span class="bp-tok-null">null<\/span>/);
+  });
+
+  it("escapes HTML-sensitive characters inside string values", () => {
+    const html = highlightJson('{"html": "<b>&"}');
+    assert.match(html, /&lt;b&gt;&amp;/);
+    assert.doesNotMatch(html, /<b>/);
+  });
+
+  it("returns an empty string for empty input", () => {
+    assert.strictEqual(highlightJson(""), "");
+  });
+
+  it("tolerates malformed JSON without throwing", () => {
+    assert.doesNotThrow(() => highlightJson('{"broken": '));
+  });
+});
+
+describe("formatBlueprintText", () => {
+  it("pretty-prints valid JSON with 2-space indentation", () => {
+    assert.strictEqual(
+      formatBlueprintText('{"steps":[{"step":"login"}]}'),
+      '{\n  "steps": [\n    {\n      "step": "login"\n    }\n  ]\n}',
+    );
+  });
+
+  it("throws for malformed JSON", () => {
+    assert.throws(() => formatBlueprintText("{invalid"));
+  });
+});
+
+describe("getInitialBlueprintCode", () => {
+  it("pretty-prints valid JSON text", () => {
+    assert.strictEqual(
+      getInitialBlueprintCode('{"steps":[]}'),
+      '{\n  "steps": []\n}',
+    );
+  });
+
+  it("returns the raw text unchanged when JSON is malformed", () => {
+    assert.strictEqual(getInitialBlueprintCode("not json"), "not json");
+  });
+
+  it("returns an empty string for blank or non-string input", () => {
+    assert.strictEqual(getInitialBlueprintCode(""), "");
+    assert.strictEqual(getInitialBlueprintCode("   "), "");
+    assert.strictEqual(getInitialBlueprintCode(undefined), "");
+  });
+});
+
+describe("createBlueprintValidationResult", () => {
+  // Mirrors this repo's src/shared/blueprint.js normalizeBlueprint contract:
+  // permissive for object input, throws for non-object JSON.
+  const normalizeBlueprint = (input) => {
+    if (!input || typeof input !== "object" || Array.isArray(input)) {
+      throw new Error("Blueprint must be a JSON object.");
+    }
+    return input;
+  };
+
+  it("reports an empty-input error without calling normalizeBlueprint", () => {
+    let called = false;
+    const result = createBlueprintValidationResult("   ", {
+      normalizeBlueprint: () => {
+        called = true;
+      },
+    });
+    assert.strictEqual(result.valid, false);
+    assert.strictEqual(result.stage, "json");
+    assert.strictEqual(called, false);
+  });
+
+  it("reports a JSON stage error for malformed JSON", () => {
+    const result = createBlueprintValidationResult("{not valid", {
+      normalizeBlueprint,
+    });
+    assert.strictEqual(result.valid, false);
+    assert.strictEqual(result.stage, "json");
+    assert.match(result.message, /Invalid JSON/);
+  });
+
+  it("reports a schema stage error when normalizeBlueprint throws", () => {
+    const result = createBlueprintValidationResult('"just a string"', {
+      normalizeBlueprint,
+    });
+    assert.strictEqual(result.valid, false);
+    assert.strictEqual(result.stage, "schema");
+    assert.match(result.message, /Blueprint must be a JSON object\./);
+  });
+
+  it("returns a valid result with the normalized blueprint", () => {
+    const result = createBlueprintValidationResult('{"steps": []}', {
+      normalizeBlueprint,
+    });
+    assert.strictEqual(result.valid, true);
+    assert.strictEqual(result.stage, "valid");
+    assert.deepStrictEqual(result.blueprint, { steps: [] });
+  });
+});
+
+describe("buildBlueprintRunUrl", () => {
+  it("sets the blueprint param and removes blueprint-url/blueprint-data", () => {
+    const url = buildBlueprintRunUrl(
+      "https://example.com/app/?blueprint-url=https://old.example/bp.json&blueprint-data=xyz&foo=bar",
+      "ENCODED",
+    );
+    const parsed = new URL(url);
+    assert.strictEqual(parsed.searchParams.get("blueprint"), "ENCODED");
+    assert.strictEqual(parsed.searchParams.has("blueprint-url"), false);
+    assert.strictEqual(parsed.searchParams.has("blueprint-data"), false);
+    assert.strictEqual(parsed.searchParams.get("foo"), "bar");
+  });
+
+  it("preserves the origin and path", () => {
+    const url = buildBlueprintRunUrl(
+      "https://example.com/index.html?x=1",
+      "abc",
+    );
+    assert.ok(url.startsWith("https://example.com/index.html?"));
+  });
+});

--- a/tests/e2e/shell.spec.mjs
+++ b/tests/e2e/shell.spec.mjs
@@ -37,6 +37,34 @@ test("toggles the runtime side panel", async ({ page }) => {
   await expect(page.locator("#side-panel")).not.toHaveClass(/is-collapsed/);
 });
 
+test("blueprint panel is editable and gates the Run button on invalid JSON", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+
+  // The CodeJar editor visually supersedes the textarea; #blueprint-textarea
+  // stays in the DOM as a hidden compatibility bridge (see
+  // src/shell/blueprint-editor.js).
+  await expect(page.locator("#blueprint-editor")).toBeVisible();
+  await expect(page.locator("#run-button")).toBeEnabled();
+  await expect(page.locator("#blueprint-status")).toHaveText(/valid/i);
+
+  const editor = page.locator("#blueprint-editor");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await page.keyboard.type("not json at all");
+
+  await expect(page.locator("#blueprint-status")).toContainText(/invalid/i);
+  await expect(page.locator("#run-button")).toBeDisabled();
+
+  // Invalid content must never trigger a navigation/reload.
+  expect(new URL(page.url()).searchParams.has("blueprint")).toBe(false);
+});
+
 test("info panel hosts the version config with a dirty-state apply", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Replaces the read-only Blueprint JSON textarea with an editable, syntax-highlighted CodeJar editor (plain-textarea fallback if the CDN can't load), inline JSON validation, and a **Run** button that re-encodes the edited blueprint into the existing `?blueprint=` URL flow and reloads the playground. Adds icon-only **Export**/**Import** buttons and a **Copy**-to-clipboard button, all in a single toolbar row above the editor.

This ports the `editable-blueprint-panel` feature already shipped in [moodle-playground](https://github.com/ateeducacion/moodle-playground) (merged as `12a3c87`), adapted to this repo's blueprint API.

## Changes

- `src/shell/blueprint-editor-core.js` (new) — pure, dependency-free helpers (JSON highlighting, validation, URL building), unit tested.
- `src/shell/blueprint-editor.js` (new) — CodeJar/DOM wiring, including a fix for a focus-handoff race where typing in the fallback textarea while CodeJar's async CDN import resolves could silently drop keystrokes.
- `src/shell/main.js` — wires the editor in; `exportBlueprint()` now serializes live editor content (and reports an error instead of exporting invalid JSON) rather than the stale in-memory blueprint.
- `index.html`, `src/styles/blueprint-editor.css`, `src/styles/app.css` — new toolbar/editor markup and styles.
- `tests/blueprint-editor-core.test.mjs` (new), `tests/e2e/shell.spec.mjs` — unit + e2e coverage, including a test that invalid JSON disables Run and never triggers navigation.

## Adaptations from moodle-playground (this repo's blueprint API differs)

- No OpenSpec change — this repo doesn't use that convention.
- This repo has no `parseBlueprint`/`validateBlueprint`/schema engine. Validation instead calls this repo's `normalizeBlueprint` (`src/shared/blueprint.js`), which is permissive (fills in defaults) — the only real failure modes are malformed JSON and non-object JSON (string/number/array), both surfaced as clear validation-stage errors.
- Run encodes via the existing (async, already gzip/base64-fallback-aware) `encodeBlueprintParam` — no separate fallback helper needed.
- New toolbar buttons use a `.bp-btn` class rather than `.icon-button`, since this repo already has a global `.icon-button` class (fixed 36×36px, used elsewhere) incompatible with the wide/labeled/primary Run button.
- Reuses this repo's existing `--color-maroon-light` focus-ring variable and the Copy icon already used by `#runtime-id-chip`.

## Test plan

- [x] `node --test tests/*.test.mjs` — 129/129 passing
- [x] `npx @biomejs/biome check` — clean (only pre-existing, unrelated warnings)
- [x] `npx playwright test tests/e2e/shell.spec.mjs` (external server) — 6/6 passing, including the new blueprint editor test