### PR TITLE
Align blueprint Run-button e2e test name with sibling playgrounds

### DIFF
--- a/tests/e2e/shell.spec.mjs
+++ b/tests/e2e/shell.spec.mjs
@@ -37,7 +37,7 @@ test("toggles the runtime side panel", async ({ page }) => {
   await expect(page.locator("#side-panel")).not.toHaveClass(/is-collapsed/);
 });
 
-test("blueprint panel is editable and gates the Run button on invalid JSON", async ({
+test("blueprint editor validates edits and gates the Run button", async ({
   page,
 }) => {
   await page.goto("/");


### PR DESCRIPTION
## Summary
- Renames the e2e test added by #112 from "blueprint panel is editable and gates the Run button on invalid JSON" to "blueprint editor validates edits and gates the Run button", matching the identical test's wording in the sibling nextcloud-playground and facturascripts-playground repos.
- Pure cosmetic alignment for cross-repo consistency — no behavior or assertion changes.

## Test plan
- [x] `node --test tests/*.test.mjs` — 129/129 passing
- [x] `npx @biomejs/biome check` — clean (pre-existing unrelated warnings in `tests/install-script-boot.test.mjs` untouched)
- [x] Ran the renamed e2e test against an isolated dev server — passes