### PR TITLE
fix: preserve empty directories in tar.zst bundle

### DIFF
--- a/scripts/build-tar-zst-bundle.mjs
+++ b/scripts/build-tar-zst-bundle.mjs
@@ -10,7 +10,7 @@
 // node:zlib zstd); CI must run Node 24 LTS.
 //
 // Usage: node scripts/build-tar-zst-bundle.mjs <stageDir> <out.tar.zst>
-// Prints JSON: { fileCount, bytes, sha256, uncompressedBytes }
+// Prints JSON: { fileCount, dirCount, bytes, sha256, uncompressedBytes }
 
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -45,7 +45,17 @@ function walk(dir, base, map) {
 const fileMap = {};
 walk(stageDir, stageDir, fileMap);
 const entries = normalizeEntries(fileMap);
-const uncompressedBytes = entries.reduce((n, e) => n + e.data.length, 0);
+// fileCount stays files-only for parity with the runtime tripwire: the streaming
+// parser counts files only (directories go to dirCount), and src/runtime/vfs.js
+// asserts stats.fileCount === manifest.bundle.fileCount. Any preserved empty
+// directory member is reported separately as dirCount so the manifest count is
+// never inflated.
+const fileCount = entries.reduce((n, e) => n + (e.type === "dir" ? 0 : 1), 0);
+const dirCount = entries.length - fileCount;
+const uncompressedBytes = entries.reduce(
+  (n, e) => n + (e.type === "dir" ? 0 : e.data.length),
+  0,
+);
 const tar = createUstarTar(entries, { mtime: 0 });
 const compressed = zlib.zstdCompressSync(tar, {
   params: {
@@ -61,7 +71,8 @@ const compressed = zlib.zstdCompressSync(tar, {
 writeFileSync(outFile, compressed);
 console.log(
   JSON.stringify({
-    fileCount: entries.length,
+    fileCount,
+    dirCount,
     bytes: compressed.length,
     sha256: createHash("sha256").update(compressed).digest("hex"),
     uncompressedBytes,

--- a/scripts/lib/tar-ustar.mjs
+++ b/scripts/lib/tar-ustar.mjs
@@ -19,15 +19,17 @@
 // drop files. bsdtar / GNU tar read the prefix split and longlink correctly too,
 // so this format keeps full file-count parity with the source tree.
 //
-// Determinism policy: entries are emitted files-only (no directory members, which
-// the runtime reconstructs anyway) in a fixed byte-wise sort, with mtime=0,
-// uid=gid=0, empty uname/gname, and a fixed mode.
+// Determinism policy: entries are emitted in a fixed byte-wise sort, with
+// mtime=0, uid=gid=0, empty uname/gname, and fixed modes. Files use typeflag '0';
+// semantically-meaningful empty directories (those no file re-creates — see
+// normalizeEntries) use typeflag '5' so they survive into the extracted tree.
 //
 // Entry-name sanitization (reject "..", strip leading "/", drop "." segments)
 // keeps the tar from carrying a path-traversal entry — the same guard the ZIP
 // boot path applies.
 
 const BLOCK = 512;
+const EMPTY_DATA = new Uint8Array(0);
 
 // --- name sanitization -------------------------------------------------------
 
@@ -47,16 +49,27 @@ export function sanitizeArchivePath(name) {
 
 /**
  * Turn a { path -> Uint8Array } map (as produced by fflate `unzipSync`) into a
- * sorted, sanitized, files-only entry list ready for createUstarTar(). Directory
- * keys (trailing "/") are dropped; unsafe paths are skipped. The sort is a stable
- * byte-wise comparison on the sanitized name so two runs over the same input
- * yield an identical archive.
+ * sorted, sanitized entry list ready for createUstarTar(). Each entry is tagged
+ * `{ type: "file", name, data }` or `{ type: "dir", name }`.
+ *
+ * Directory members (trailing "/") are preserved ONLY when no file will create
+ * them implicitly — i.e. semantically-meaningful empty directories that no file
+ * recreates. A source tree can carry a directory whose only files were removed by
+ * the build trim; the source ZIP still ships it as an explicit empty directory
+ * member, and the runtime needs that directory to exist. Directories implied by a
+ * file (every ancestor path of a kept file) are NOT emitted as redundant members
+ * — the streaming extractor reconstructs them from each file's parent path.
+ *
+ * Unsafe paths (".." traversal) are skipped for both files and directories. The
+ * sort is a stable byte-wise comparison on the sanitized name so two runs over
+ * the same input yield an identical archive.
  */
 export function normalizeEntries(fileMap) {
-  const entries = [];
+  const files = [];
+  const dirCandidates = [];
   for (const rawName of Object.keys(fileMap)) {
     const normalized = normalizeArchiveName(rawName);
-    if (normalized.endsWith("/")) continue; // directory member, skip
+    const isDir = normalized.endsWith("/");
     let name;
     try {
       name = sanitizeArchivePath(normalized);
@@ -64,8 +77,31 @@ export function normalizeEntries(fileMap) {
       continue; // path traversal — drop, never write outside root
     }
     if (!name) continue;
-    entries.push({ name, data: fileMap[rawName] });
+    if (isDir) dirCandidates.push(name);
+    else files.push({ type: "file", name, data: fileMap[rawName] });
   }
+
+  // Every ancestor directory of a kept file is created implicitly by the
+  // extractor; collect them so we never emit a redundant directory member.
+  const impliedDirs = new Set();
+  for (const file of files) {
+    let idx = file.name.lastIndexOf("/");
+    while (idx > 0) {
+      const dir = file.name.slice(0, idx);
+      if (impliedDirs.has(dir)) break;
+      impliedDirs.add(dir);
+      idx = dir.lastIndexOf("/");
+    }
+  }
+
+  const seenDir = new Set();
+  const entries = files;
+  for (const name of dirCandidates) {
+    if (impliedDirs.has(name) || seenDir.has(name)) continue;
+    seenDir.add(name);
+    entries.push({ type: "dir", name });
+  }
+
   // Byte-wise (codepoint) sort — NOT localeCompare, which is locale-sensitive
   // and would make the archive non-reproducible across environments.
   entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
@@ -159,18 +195,36 @@ function padToBlock(chunks, byteLength) {
  * Options pin the metadata (mtime/uid/gid/mode) so output is reproducible.
  */
 export function createUstarTar(entries, options = {}) {
-  const { mtime = 0, uid = 0, gid = 0, mode = 0o644 } = options;
+  const {
+    mtime = 0,
+    uid = 0,
+    gid = 0,
+    mode = 0o644,
+    dirMode = 0o755,
+  } = options;
   const chunks = [];
 
   for (const entry of entries) {
+    const isDir = entry.type === "dir";
+    // Directory members carry a trailing slash (USTAR convention) and no body;
+    // the trailing slash + typeflag '5' both signal "directory" to the reader.
+    const entryName = isDir
+      ? entry.name.endsWith("/")
+        ? entry.name
+        : `${entry.name}/`
+      : entry.name;
     const data =
-      entry.data instanceof Uint8Array ? entry.data : Buffer.from(entry.data);
-    const split = splitTarName(entry.name);
+      isDir || entry.data == null
+        ? EMPTY_DATA
+        : entry.data instanceof Uint8Array
+          ? entry.data
+          : Buffer.from(entry.data);
+    const split = splitTarName(entryName);
 
     if (split.longLink) {
       // GNU `././@LongLink`: an 'L'-type entry whose body is the full name + NUL,
       // applied to the next entry.
-      const longName = Buffer.from(`${entry.name}\0`, "utf8");
+      const longName = Buffer.from(`${entryName}\0`, "utf8");
       chunks.push(
         headerBlock({
           name: "././@LongLink",
@@ -194,12 +248,14 @@ export function createUstarTar(entries, options = {}) {
         mtime,
         uid,
         gid,
-        mode,
-        typeflag: "0",
+        mode: isDir ? dirMode : mode,
+        typeflag: isDir ? "5" : "0",
       }),
     );
-    chunks.push(Buffer.from(data.buffer, data.byteOffset, data.byteLength));
-    padToBlock(chunks, data.length);
+    if (data.length > 0) {
+      chunks.push(Buffer.from(data.buffer, data.byteOffset, data.byteLength));
+      padToBlock(chunks, data.length);
+    }
   }
 
   // Two zero blocks mark end-of-archive.
@@ -219,9 +275,11 @@ function readOctal(block, offset, length) {
 
 /**
  * Minimal tar reader that understands USTAR entries (incl. the prefix/name
- * split) and GNU `././@LongLink` names. Returns [{ name, data }]. Used by tests
- * to prove round-trip fidelity and as a reference for the runtime streaming
- * extractor prototype.
+ * split) and GNU `././@LongLink` names. Returns file entries as
+ * `{ name, data }` and directory entries (typeflag '5' or a trailing-slash name)
+ * as `{ name, type: "dir" }` — the directory name is returned without its
+ * trailing slash. Used by tests to prove round-trip fidelity and as a reference
+ * for the runtime streaming extractor prototype.
  */
 export function readUstarTar(buffer) {
   const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
@@ -247,10 +305,16 @@ export function readUstarTar(buffer) {
       pendingName = data.toString("utf8").replace(/\0.*$/, "");
       continue;
     }
-    if (typeflag !== "0" && typeflag !== "\0") continue; // ignore non-file types
 
     const name = pendingName ?? (prefix ? `${prefix}/${rawName}` : rawName);
     pendingName = null;
+
+    if (typeflag === "5" || name.endsWith("/")) {
+      entries.push({ name: name.replace(/\/+$/, ""), type: "dir" });
+      continue;
+    }
+    if (typeflag !== "0" && typeflag !== "\0") continue; // ignore exotic types
+
     entries.push({ name, data: Uint8Array.prototype.slice.call(data) });
   }
   return entries;

--- a/tests/streaming-tar-extract.test.mjs
+++ b/tests/streaming-tar-extract.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  extractTarStreamToPhp,
   StreamingTarParser,
   sanitizeTarPath,
 } from "../lib/streaming-tar-extract.js";
@@ -188,6 +189,58 @@ describe("StreamingTarParser", () => {
     const parser = new StreamingTarParser({ onEntry: () => {} });
     parser.push(tar.subarray(0, 512 + 400)); // header + partial data
     assert.throws(() => parser.end(), /Truncated/);
+  });
+
+  it("11. surfaces an empty directory written by createUstarTar", () => {
+    // End-to-end regression for the tar.zst core bundle: a semantically-meaningful
+    // empty directory must survive the production writer -> streaming extractor
+    // path (see tar-ustar.test.mjs for the writer-side assertions).
+    const tar = Buffer.from(
+      createUstarTar(
+        normalizeEntries({ "emptydir/": enc(""), "a.txt": enc("a") }),
+      ),
+    );
+    const { entries, stats } = collect(tar, 64);
+    assert.equal(stats.dirCount, 1);
+    const dir = entries.find((e) => e.type === "dir" && e.path === "emptydir");
+    assert.ok(dir, "empty directory must survive writer -> extractor");
+  });
+});
+
+describe("extractTarStreamToPhp", () => {
+  it("creates an empty directory on the filesystem via mkdirTree", async () => {
+    const tar = Buffer.from(
+      createUstarTar(
+        normalizeEntries({
+          "emptydir/": enc(""),
+          "modules/quiz/version.php": enc("<?php"),
+        }),
+      ),
+    );
+    const mkdirs = [];
+    const writes = [];
+    const fakePhp = {
+      _php: {
+        mkdirTree: (d) => mkdirs.push(d),
+        writeFile: (p) => writes.push(p),
+      },
+    };
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(tar);
+        controller.close();
+      },
+    });
+    const stats = await extractTarStreamToPhp(stream, fakePhp, "/www/omeka");
+    // The semantically-meaningful empty directory is materialized even though it
+    // holds no file.
+    assert.ok(
+      mkdirs.includes("/www/omeka/emptydir"),
+      `expected /www/omeka/emptydir to be created; got ${JSON.stringify(mkdirs)}`,
+    );
+    assert.ok(writes.includes("/www/omeka/modules/quiz/version.php"));
+    assert.equal(stats.dirCount, 1);
+    assert.equal(stats.fileCount, 1);
   });
 });
 

--- a/tests/tar-ustar.test.mjs
+++ b/tests/tar-ustar.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { describe, it } from "node:test";
+import {
+  createUstarTar,
+  normalizeEntries,
+  readUstarTar,
+} from "../scripts/lib/tar-ustar.mjs";
+
+const sha256 = (buf) => createHash("sha256").update(buf).digest("hex");
+const bytes = (s) => new Uint8Array(Buffer.from(s));
+
+describe("tar-ustar empty directory preservation", () => {
+  // Regression: a source tree can carry a directory whose only files were removed
+  // by the build trim. The source ZIP still ships it as an explicit empty
+  // directory member; the files-only tar writer used to drop it, so the
+  // semantically-meaningful empty directory never existed in the extracted tree.
+
+  it("preserves an explicit empty directory (no file descendant)", () => {
+    const entries = normalizeEntries({
+      "extras/": bytes(""),
+      "modules/quiz/version.php": bytes("<?php"),
+    });
+    const dir = entries.find((e) => e.name === "extras");
+    assert.ok(dir, "empty extras/ directory must be preserved");
+    assert.equal(dir.type, "dir");
+    // Directories implied by a file are NOT emitted as redundant members —
+    // the streaming extractor reconstructs them from each file's parent path.
+    assert.ok(!entries.some((e) => e.type === "dir" && e.name === "modules"));
+    assert.ok(
+      !entries.some((e) => e.type === "dir" && e.name === "modules/quiz"),
+    );
+  });
+
+  it("drops populated directory members that a file recreates (real fflate shape)", () => {
+    // fflate's unzipSync() yields an EXPLICIT trailing-slash member for EVERY
+    // directory in the ZIP, including populated ones. Only the truly empty
+    // `keepme/` must survive; `a/` and `a/b/` are recreated by their file and
+    // MUST be dropped (invariant: no redundant directory members, else the tar
+    // gains spurious typeflag-5 entries and dirCount / sha256 drift). Guards the
+    // impliedDirs dedup, which the empty-only maps above never exercise.
+    const entries = normalizeEntries({
+      "a/": bytes(""),
+      "a/b/": bytes(""),
+      "a/b/f.txt": bytes("data"),
+      "keepme/": bytes(""),
+    });
+    const dirs = entries.filter((e) => e.type === "dir").map((e) => e.name);
+    assert.deepEqual(dirs, ["keepme"]);
+  });
+
+  it("preserves a nested empty directory but not those implied by files", () => {
+    const entries = normalizeEntries({
+      "plugin/tool/version.php": bytes("<?php"),
+      "plugin/tool/lang/en/tool.php": bytes("<?php"),
+      "plugin/tool/widgets/": bytes(""),
+    });
+    const dirs = entries.filter((e) => e.type === "dir").map((e) => e.name);
+    assert.deepEqual(dirs, ["plugin/tool/widgets"]);
+  });
+
+  it("emits a USTAR directory header (typeflag 5, size 0) that round-trips", () => {
+    const tar = createUstarTar(
+      normalizeEntries({ "extras/": bytes(""), "a.txt": bytes("a") }),
+      { mtime: 0 },
+    );
+    const back = readUstarTar(tar);
+    const dir = back.find((e) => e.name === "extras");
+    assert.ok(dir, "directory entry should round-trip via the reader");
+    assert.equal(dir.type, "dir");
+    assert.equal(dir.data, undefined);
+    // Files still round-trip alongside directories.
+    const file = back.find((e) => e.name === "a.txt");
+    assert.ok(file && Buffer.from(file.data).equals(Buffer.from(bytes("a"))));
+  });
+
+  it("does not count directories as files", () => {
+    const entries = normalizeEntries({
+      "extras/": bytes(""),
+      "a.txt": bytes("a"),
+      "b.txt": bytes("b"),
+    });
+    assert.equal(entries.filter((e) => e.type !== "dir").length, 2);
+    assert.equal(entries.filter((e) => e.type === "dir").length, 1);
+  });
+
+  it("skips unsafe directory paths (path traversal)", () => {
+    const entries = normalizeEntries({
+      "../evil/": bytes(""),
+      "plugin/tool/../../evil/": bytes(""),
+      "ok/": bytes(""),
+    });
+    const dirs = entries.filter((e) => e.type === "dir").map((e) => e.name);
+    assert.deepEqual(dirs, ["ok"]);
+  });
+
+  it("is deterministic with directory entries (stable sha256 across two builds)", () => {
+    const map = {
+      "extras/": bytes(""),
+      "admin/tool/": bytes(""),
+      "modules/quiz/version.php": bytes("<?php"),
+      "z.txt": bytes("z"),
+    };
+    const a = createUstarTar(normalizeEntries(map), { mtime: 0 });
+    const b = createUstarTar(normalizeEntries(map), { mtime: 0 });
+    assert.ok(Buffer.from(a).equals(Buffer.from(b)));
+    assert.equal(sha256(a), sha256(b));
+    assert.equal(a.length % 512, 0);
+  });
+});


### PR DESCRIPTION
## Summary

The shared USTAR tar writer's `normalizeEntries()` dropped **all** directory members. When a directory in the source tree ends up empty (e.g. its only files were removed by the build trim), the source ZIP still carries it as an explicit empty-directory member, but the files-only tar writer dropped it — and the streaming extractor only recreates directories from the parent path of each **file** it writes. So semantically-meaningful empty directories vanished from the runtime filesystem.

## Fix

- `scripts/lib/tar-ustar.mjs`
  - `normalizeEntries()` now preserves directory members that no kept file recreates. Directories implied by a file (every ancestor path of a kept file) are still excluded, so no redundant entries are emitted and the archive stays deterministic.
  - `createUstarTar()` emits USTAR typeflag-5 headers (mode `0o755`, size 0, no body) for those preserved directories.
  - `readUstarTar()` surfaces directory entries as `{ name, type: "dir" }` (typeflag `5` or trailing-slash name), files still as `{ name, data }`.
- `scripts/build-tar-zst-bundle.mjs` reports `fileCount` (files only) and a separate `dirCount`. **`fileCount` stays files-only** so the manifest count and the runtime file-count parity tripwire in `src/runtime/vfs.js` are unaffected (the streaming parser counts files only; directories go to `dirCount`).
- `lib/streaming-tar-extract.js` is **unchanged** — it already materializes typeflag-5 / trailing-slash entries via `mkdirTree`.

## Tests

- New `tests/tar-ustar.test.mjs`: empty-directory preservation, the impliedDirs dedup (realistic fflate-shaped map with explicit trailing-slash members), typeflag-5 round-trip, dir-not-counted-as-file, path-traversal skip, and determinism (stable sha256) with directory entries.
- `tests/streaming-tar-extract.test.mjs`: an empty directory written by `createUstarTar` survives the writer → `StreamingTarParser` path (`dirCount === 1`), and `extractTarStreamToPhp` creates it on the filesystem via `mkdirTree`.
- `node --test tests/*.test.mjs`: 147 pass, 0 fail. Biome clean. Verified the dedup test is non-vacuous (removing the `impliedDirs` guard makes exactly that test fail).

Ports the shared-kit fix from ateeducacion/moodle-playground#215 (root cause: ateeducacion/moodle-playground#214).