### PR TITLE
Add Omeka S 4.3.0-alpha support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,32 +15,33 @@ OMEKA_REF_BRANCH ?=
 # Common overrides:
 #   make serve PORT=9090
 #   make bundle OMEKA_VERSION=4.1.1
-#   make bundle OMEKA_VERSION=4.2.1 OMEKA_REF=https://github.com/<org>/omeka-s.git OMEKA_REF_BRANCH=<branch>
+#   make bundle OMEKA_VERSION=4.3.0-alpha OMEKA_REF=https://github.com/<org>/omeka-s.git OMEKA_REF_BRANCH=<branch>
 
-.PHONY: help up deps prepare bundle bundle-all bundle-4.1.1 bundle-4.2.1 serve clean reset test lint format
+.PHONY: help up deps prepare bundle bundle-all bundle-4.1.1 bundle-4.2.1 bundle-4.3.0-alpha serve clean reset test lint format
 
 help:
 	@printf '%s\n' \
 		'Omeka S Playground Make targets:' \
 		'' \
-		'  make deps          Install npm dependencies' \
-		'  make prepare       Sync browser deps and prepare runtime assets' \
-		'  make bundle        Build the readonly Omeka bundle for the default version' \
-		'  make bundle-all    Build bundles for every supported Omeka version' \
-		'  make bundle-4.1.1  Build only the Omeka 4.1.1 bundle' \
-		'  make bundle-4.2.1  Build only the Omeka 4.2.1 bundle' \
-		'  make serve         Start the local dev server' \
-		'  make up            Run bundle-all + serve' \
-		'  make test          Run tests' \
-		'  make lint          Check code with Biome' \
-		'  make format        Auto-fix code with Biome' \
-		'  make clean         Remove generated caches and bundle artifacts' \
-		'  make reset         Alias of clean plus cache reset' \
+		'  make deps                Install npm dependencies' \
+		'  make prepare             Sync browser deps and prepare runtime assets' \
+		'  make bundle              Build the readonly Omeka bundle for the default version' \
+		'  make bundle-all          Build bundles for every supported Omeka version' \
+		'  make bundle-4.1.1        Build only the Omeka 4.1.1 bundle' \
+		'  make bundle-4.2.1        Build only the Omeka 4.2.1 bundle' \
+		'  make bundle-4.3.0-alpha  Build only the Omeka 4.3.0-alpha bundle' \
+		'  make serve               Start the local dev server' \
+		'  make up                  Run bundle-all + serve' \
+		'  make test                Run tests' \
+		'  make lint                Check code with Biome' \
+		'  make format              Auto-fix code with Biome' \
+		'  make clean               Remove generated caches and bundle artifacts' \
+		'  make reset               Alias of clean plus cache reset' \
 		'' \
 		'Common overrides:' \
 		'  PORT=9090 make serve' \
 		'  OMEKA_VERSION=4.1.1 make bundle' \
-		'  OMEKA_REF=<repo> OMEKA_REF_BRANCH=<branch> make bundle OMEKA_VERSION=4.2.1'
+		'  OMEKA_REF=<repo> OMEKA_REF_BRANCH=<branch> make bundle OMEKA_VERSION=4.3.0-alpha'
 
 deps:
 	npm install
@@ -53,7 +54,7 @@ prepare: deps
 bundle: prepare
 	OMEKA_VERSION=$(OMEKA_VERSION) OMEKA_REF=$(OMEKA_REF) OMEKA_REF_BRANCH=$(OMEKA_REF_BRANCH) npm run bundle
 
-bundle-all: prepare bundle-4.1.1 bundle-4.2.1
+bundle-all: prepare bundle-4.1.1 bundle-4.2.1 bundle-4.3.0-alpha
 
 # Per-version targets so recursive make can parallelise independent builds
 # (they share only the worker bundle and the vendor cache).
@@ -62,6 +63,9 @@ bundle-4.1.1:
 
 bundle-4.2.1:
 	OMEKA_VERSION=4.2.1 OMEKA_REF=$(OMEKA_REF) OMEKA_REF_BRANCH=$(OMEKA_REF_BRANCH) npm run bundle
+
+bundle-4.3.0-alpha:
+	OMEKA_VERSION=4.3.0-alpha OMEKA_REF=$(OMEKA_REF) OMEKA_REF_BRANCH=$(OMEKA_REF_BRANCH) npm run bundle
 
 serve:
 	PORT=$(PORT) node ./scripts/dev-server.mjs

--- a/playground.config.json
+++ b/playground.config.json
@@ -33,6 +33,13 @@
       "phpVersion": "8.3",
       "omekaVersion": "4.1.1",
       "default": false
+    },
+    {
+      "id": "php83-omeka430alpha",
+      "label": "PHP 8.3 + Omeka S 4.3.0-alpha",
+      "phpVersion": "8.3",
+      "omekaVersion": "4.3.0-alpha",
+      "default": false
     }
   ]
 }

--- a/src/runtime/php-loader.js
+++ b/src/runtime/php-loader.js
@@ -160,6 +160,9 @@ export function createPhpRuntime(
         absoluteUrl,
         webRoot: webRoot || OMEKA_ROOT,
       });
+      // bootstrap.js removes stale persisted files through the deferred API.
+      // Keep that operation backed by PHP's public filesystem method so the
+      // fs-journal receives the native filesystem.write event.
       wrapped.unlink = (path) => php.unlink(path);
 
       // Copy all methods from the wrapped instance onto this deferred object

--- a/src/runtime/php-loader.js
+++ b/src/runtime/php-loader.js
@@ -160,9 +160,7 @@ export function createPhpRuntime(
         absoluteUrl,
         webRoot: webRoot || OMEKA_ROOT,
       });
-      // bootstrap.js removes stale persisted files through the deferred API.
-      // Keep that operation backed by PHP's public filesystem method so the
-      // fs-journal receives the native filesystem.write event.
+      // Preserve PHP's filesystem.write event for persisted file removals.
       wrapped.unlink = (path) => php.unlink(path);
 
       // Copy all methods from the wrapped instance onto this deferred object

--- a/src/runtime/php-loader.js
+++ b/src/runtime/php-loader.js
@@ -160,6 +160,7 @@ export function createPhpRuntime(
         absoluteUrl,
         webRoot: webRoot || OMEKA_ROOT,
       });
+      wrapped.unlink = (path) => php.unlink(path);
 
       // Copy all methods from the wrapped instance onto this deferred object
       for (const key of Object.keys(wrapped)) {
@@ -196,6 +197,9 @@ export function createPhpRuntime(
       throw new Error("PHP runtime not initialized. Call refresh() first.");
     },
     async readFile() {
+      throw new Error("PHP runtime not initialized. Call refresh() first.");
+    },
+    async unlink() {
       throw new Error("PHP runtime not initialized. Call refresh() first.");
     },
     async run() {

--- a/src/shared/omeka-versions.js
+++ b/src/shared/omeka-versions.js
@@ -19,7 +19,7 @@ export const OMEKA_VERSIONS = [
     source: {
       type: "git",
       repository: "https://github.com/ateeducacion/omeka-s.git",
-      branch: "feature/experimental-sqlite-support-4.1.1",
+      branch: "feature/experimental-sqlite-support-4.1",
     },
     default: false,
   },
@@ -33,9 +33,23 @@ export const OMEKA_VERSIONS = [
     source: {
       type: "git",
       repository: "https://github.com/ateeducacion/omeka-s.git",
-      branch: "feature/experimental-sqlite-support",
+      branch: "feature/experimental-sqlite-support-4.2",
     },
     default: true,
+  },
+  {
+    version: "4.3.0-alpha",
+    label: "Omeka S 4.3.0-alpha",
+    slug: "4.3.0-alpha",
+    manifestFile: "4.3.0-alpha.json",
+    bundleDir: "4.3.0-alpha",
+    phpVersions: ["8.1", "8.2", "8.3", "8.4", "8.5"],
+    source: {
+      type: "git",
+      repository: "https://github.com/ateeducacion/omeka-s.git",
+      branch: "feature/experimental-sqlite-support",
+    },
+    default: false,
   },
 ];
 
@@ -52,6 +66,10 @@ function normalizeStringParam(value) {
 
   const normalized = String(value).trim();
   return normalized || null;
+}
+
+function buildOmekaRuntimeToken(version) {
+  return String(version).replaceAll(/[^A-Za-z0-9]/gu, "");
 }
 
 /**
@@ -129,21 +147,20 @@ export function resolveOmekaVersion(input) {
 
 /**
  * Build a runtime ID encoding both PHP version and Omeka version.
- * e.g., "php83-omeka421", "php83-omeka411".
+ * e.g., "php83-omeka421", "php83-omeka411", "php83-omeka430alpha".
  */
 export function buildRuntimeId(phpVersion, omekaVersion) {
   const phpPart = `php${String(phpVersion).replace(".", "")}`;
   const meta = getOmekaVersionMetadata(omekaVersion);
-  const omekaPart = meta
-    ? `omeka${meta.version.replaceAll(".", "")}`
-    : `omeka${String(omekaVersion).replaceAll(/[^A-Za-z0-9]/gu, "")}`;
+  const resolvedVersion = meta?.version || omekaVersion;
+  const omekaPart = `omeka${buildOmekaRuntimeToken(resolvedVersion)}`;
   return `${phpPart}-${omekaPart}`;
 }
 
 /**
  * Parse a runtime ID back to { phpVersion, omekaVersion }.
  *
- * Accepts the new "phpXY-omekaNNN" format and the legacy "phpXY" format
+ * Accepts the new "phpXY-omekaVERSION" format and the legacy "phpXY" format
  * (which maps to the default Omeka version).
  */
 export function parseRuntimeId(runtimeId) {
@@ -151,21 +168,21 @@ export function parseRuntimeId(runtimeId) {
     return null;
   }
 
-  const newMatch = runtimeId.match(/^php(\d)(\d)-omeka(\d+)$/u);
+  const newMatch = runtimeId.match(/^php(\d)(\d)-omeka([A-Za-z0-9]+)$/u);
   if (newMatch) {
     const phpVersion = `${newMatch[1]}.${newMatch[2]}`;
-    const digits = newMatch[3];
+    const versionToken = newMatch[3];
     const byExact = OMEKA_VERSIONS.find(
-      (entry) => entry.version.replaceAll(".", "") === digits,
+      (entry) => buildOmekaRuntimeToken(entry.version) === versionToken,
     );
     if (byExact) {
       return { phpVersion, omekaVersion: byExact.version };
     }
 
-    // Tolerate shortened forms like "omeka41" -> try "4.1" loose match.
-    if (digits.length >= 2) {
+    // Tolerate shortened numeric forms like "omeka41" -> try "4.1".
+    if (/^\d+$/u.test(versionToken) && versionToken.length >= 2) {
       const loose = resolveOmekaVersion(
-        `${digits[0]}.${digits.slice(1)}`.replace(
+        `${versionToken[0]}.${versionToken.slice(1)}`.replace(
           /^(\d+)\.(\d)(\d+)$/u,
           "$1.$2.$3",
         ),

--- a/tests/omeka-versions.test.mjs
+++ b/tests/omeka-versions.test.mjs
@@ -36,14 +36,8 @@ describe("OMEKA_VERSIONS", () => {
       OMEKA_VERSIONS.map((entry) => [entry.version, entry.source.branch]),
     );
 
-    assert.equal(
-      branches["4.1.1"],
-      "feature/experimental-sqlite-support-4.1",
-    );
-    assert.equal(
-      branches["4.2.1"],
-      "feature/experimental-sqlite-support-4.2",
-    );
+    assert.equal(branches["4.1.1"], "feature/experimental-sqlite-support-4.1");
+    assert.equal(branches["4.2.1"], "feature/experimental-sqlite-support-4.2");
     assert.equal(
       branches["4.3.0-alpha"],
       "feature/experimental-sqlite-support",
@@ -259,10 +253,7 @@ describe("buildManifestFilename", () => {
   it("produces the declared manifest filename for each version", () => {
     assert.equal(buildManifestFilename("4.1.1"), "4.1.1.json");
     assert.equal(buildManifestFilename("4.2.1"), "4.2.1.json");
-    assert.equal(
-      buildManifestFilename("4.3.0-alpha"),
-      "4.3.0-alpha.json",
-    );
+    assert.equal(buildManifestFilename("4.3.0-alpha"), "4.3.0-alpha.json");
   });
 
   it("falls back to latest.json for unknown versions", () => {

--- a/tests/omeka-versions.test.mjs
+++ b/tests/omeka-versions.test.mjs
@@ -22,12 +22,32 @@ import {
 } from "../src/shared/omeka-versions.js";
 
 describe("OMEKA_VERSIONS", () => {
-  it("includes 4.1.1 and 4.2.1 and picks 4.2.1 as default", () => {
-    const versions = OMEKA_VERSIONS.map((entry) => entry.version);
-    assert.ok(versions.includes("4.1.1"));
-    assert.ok(versions.includes("4.2.1"));
+  it("includes the supported 4.1, 4.2, and 4.3 alpha versions", () => {
+    assert.deepEqual(
+      OMEKA_VERSIONS.map((entry) => entry.version),
+      ["4.1.1", "4.2.1", "4.3.0-alpha"],
+    );
     assert.equal(getDefaultOmekaVersion().version, "4.2.1");
     assert.equal(DEFAULT_OMEKA_VERSION, "4.2.1");
+  });
+
+  it("uses the matching SQLite support branch for each Omeka line", () => {
+    const branches = Object.fromEntries(
+      OMEKA_VERSIONS.map((entry) => [entry.version, entry.source.branch]),
+    );
+
+    assert.equal(
+      branches["4.1.1"],
+      "feature/experimental-sqlite-support-4.1",
+    );
+    assert.equal(
+      branches["4.2.1"],
+      "feature/experimental-sqlite-support-4.2",
+    );
+    assert.equal(
+      branches["4.3.0-alpha"],
+      "feature/experimental-sqlite-support",
+    );
   });
 
   it("exposes the full PHP matrix and a sensible default", () => {
@@ -40,6 +60,10 @@ describe("getOmekaVersionMetadata", () => {
   it("matches by exact version string", () => {
     assert.equal(getOmekaVersionMetadata("4.1.1")?.version, "4.1.1");
     assert.equal(getOmekaVersionMetadata("4.2.1")?.version, "4.2.1");
+    assert.equal(
+      getOmekaVersionMetadata("4.3.0-alpha")?.version,
+      "4.3.0-alpha",
+    );
   });
 
   it("returns null for unknown versions", () => {
@@ -52,11 +76,13 @@ describe("resolveOmekaVersion", () => {
   it("accepts exact version strings", () => {
     assert.equal(resolveOmekaVersion("4.1.1"), "4.1.1");
     assert.equal(resolveOmekaVersion("4.2.1"), "4.2.1");
+    assert.equal(resolveOmekaVersion("4.3.0-alpha"), "4.3.0-alpha");
   });
 
   it("resolves a major.minor request to the declared patch version", () => {
     assert.equal(resolveOmekaVersion("4.1"), "4.1.1");
     assert.equal(resolveOmekaVersion("4.2"), "4.2.1");
+    assert.equal(resolveOmekaVersion("4.3"), "4.3.0-alpha");
   });
 
   it("returns null for unknown input", () => {
@@ -98,6 +124,13 @@ describe("buildRuntimeId / parseRuntimeId", () => {
     assert.deepEqual(parseRuntimeId(id411), {
       phpVersion: "8.3",
       omekaVersion: "4.1.1",
+    });
+
+    const id430alpha = buildRuntimeId("8.3", "4.3.0-alpha");
+    assert.equal(id430alpha, "php83-omeka430alpha");
+    assert.deepEqual(parseRuntimeId(id430alpha), {
+      phpVersion: "8.3",
+      omekaVersion: "4.3.0-alpha",
     });
   });
 
@@ -157,10 +190,10 @@ describe("resolveVersions / resolveRuntimeSelection", () => {
   });
 
   it("resolveRuntimeSelection returns a consistent runtime id", () => {
-    const selection = resolveRuntimeSelection({ omeka: "4.1", php: "8.3" });
-    assert.equal(selection.omekaVersion, "4.1.1");
+    const selection = resolveRuntimeSelection({ omeka: "4.3", php: "8.3" });
+    assert.equal(selection.omekaVersion, "4.3.0-alpha");
     assert.equal(selection.phpVersion, "8.3");
-    assert.equal(selection.runtimeId, "php83-omeka411");
+    assert.equal(selection.runtimeId, "php83-omeka430alpha");
   });
 });
 
@@ -194,12 +227,12 @@ describe("resolveRuntimeConfig", () => {
 
   it("synthesises a runtime entry for unconfigured combinations", () => {
     const resolved = resolveRuntimeConfig(fakeConfig, {
-      runtimeId: "php85-omeka421",
+      runtimeId: "php83-omeka430alpha",
     });
-    assert.equal(resolved.id, "php85-omeka421");
-    assert.equal(resolved.phpVersion, "8.5");
-    assert.equal(resolved.omekaVersion, "4.2.1");
-    assert.equal(resolved.label, "PHP 8.5 + Omeka S 4.2.1");
+    assert.equal(resolved.id, "php83-omeka430alpha");
+    assert.equal(resolved.phpVersion, "8.3");
+    assert.equal(resolved.omekaVersion, "4.3.0-alpha");
+    assert.equal(resolved.label, "PHP 8.3 + Omeka S 4.3.0-alpha");
   });
 
   it("returns null when the config has no runtimes", () => {
@@ -216,9 +249,9 @@ describe("parseQueryParams", () => {
   });
 
   it("reads from an existing URL object", () => {
-    const url = new URL("https://example.com/?omekaVersion=4.2.1");
+    const url = new URL("https://example.com/?omekaVersion=4.3.0-alpha");
     const parsed = parseQueryParams(url);
-    assert.equal(parsed.omekaVersion, "4.2.1");
+    assert.equal(parsed.omekaVersion, "4.3.0-alpha");
   });
 });
 
@@ -226,6 +259,10 @@ describe("buildManifestFilename", () => {
   it("produces the declared manifest filename for each version", () => {
     assert.equal(buildManifestFilename("4.1.1"), "4.1.1.json");
     assert.equal(buildManifestFilename("4.2.1"), "4.2.1.json");
+    assert.equal(
+      buildManifestFilename("4.3.0-alpha"),
+      "4.3.0-alpha.json",
+    );
   });
 
   it("falls back to latest.json for unknown versions", () => {


### PR DESCRIPTION
## Summary

- add Omeka S 4.3.0-alpha to the version selector and runtime configuration
- map each supported Omeka line to its matching SQLite support branch
- replace the obsolete 4.1.1 branch reference with `feature/experimental-sqlite-support-4.1`
- use `feature/experimental-sqlite-support-4.2` for Omeka S 4.2.1
- use `feature/experimental-sqlite-support` for Omeka S 4.3.0-alpha
- add a `bundle-4.3.0-alpha` target and include it in `bundle-all`
- support prerelease version tokens in runtime IDs
- expose the native `PHP.unlink()` method through the deferred runtime API so version changes can remove stale persisted state

## Why

The playground only exposed Omeka S 4.1.1 and 4.2.1, and its source metadata still referenced the obsolete `feature/experimental-sqlite-support-4.1.1` branch. The fork now provides separate SQLite support branches for the 4.1 and 4.2 release lines, while the generic SQLite branch tracks `develop`, currently Omeka S 4.3.0-alpha.

When switching an existing playground session to a different Omeka bundle, `bootstrapOmeka()` removes the stale database and manifest state. The deferred PHP runtime did not expose the native `unlink()` filesystem method, causing `TypeError: php.unlink is not a function` during the version-mismatch reset.

Omeka S 4.2.1 remains the default stable version. Omeka S 4.3.0-alpha is available as an explicit selection.

## Validation

- syntax checks pass
- unit tests pass
- Biome lint passes
- Playwright E2E tests pass
- all supported Omeka bundles build successfully
- Cloudflare Pages PR preview deployment succeeds
