### PR TITLE
Fix bundling for all supported PHP runtimes

### DIFF
--- a/scripts/esbuild.worker.mjs
+++ b/scripts/esbuild.worker.mjs
@@ -7,18 +7,20 @@ import { dirname, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
+import { ALL_PHP_VERSIONS as SUPPORTED_PHP_VERSIONS } from "../src/shared/omeka-versions.js";
+
 const require = createRequire(import.meta.url);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoDir = resolvePath(scriptDir, "..");
 
-// Only bundle the PHP runtime versions this playground actually offers. The
-// monolithic @php-wasm/web's loadWebRuntime() switch dynamically imports every
-// @php-wasm/web-X-Y package, so esbuild can't tree-shake and would emit all 8
-// versions' .wasm (~798 MB) into dist/ — even though the browser only ever
-// downloads the one version a session selects. Stub the non-offered version
-// packages so their assets are never emitted (a deploy/CI/disk reduction;
-// runtime behavior for the offered versions is unchanged).
-const ALL_PHP_VERSIONS = [
+// Only bundle the PHP runtime versions supported by the compatibility matrix.
+// The shell can synthesize every valid PHP/Omeka combination even when
+// playground.config.json contains only a curated list of default runtimes.
+// The monolithic @php-wasm/web's loadWebRuntime() switch dynamically imports
+// every @php-wasm/web-X-Y package, so esbuild can't tree-shake and would emit
+// all 8 versions' .wasm (~798 MB) into dist/. Stub only the unsupported version
+// packages so every runtime offered by the UI remains available.
+const PHP_WASM_VERSIONS = [
   "5-2",
   "7-4",
   "8-0",
@@ -28,19 +30,12 @@ const ALL_PHP_VERSIONS = [
   "8-4",
   "8-5",
 ];
-const offeredPhp = [
-  ...new Set(
-    (
-      JSON.parse(
-        readFileSync(resolvePath(repoDir, "playground.config.json"), "utf8"),
-      ).runtimes || []
-    )
-      .map((r) => r.phpVersion)
-      .filter(Boolean),
-  ),
-];
-const keepVersions = offeredPhp.map((v) => v.replace(".", "-"));
-const dropVersions = ALL_PHP_VERSIONS.filter((v) => !keepVersions.includes(v));
+const keepVersions = SUPPORTED_PHP_VERSIONS.map((version) =>
+  version.replace(".", "-"),
+);
+const dropVersions = PHP_WASM_VERSIONS.filter(
+  (version) => !keepVersions.includes(version),
+);
 
 const stripUnusedPhpVersions = {
   name: "strip-unused-php-versions",


### PR DESCRIPTION
## Summary

- derive the PHP runtimes bundled by esbuild from the shared compatibility matrix
- bundle PHP 8.1, 8.2, 8.3, 8.4, and 8.5
- continue stubbing PHP versions that are not supported by Omeka S Playground

## Root cause

The UI can synthesize every valid PHP and Omeka S combination declared in `src/shared/omeka-versions.js`, but the worker build only preserved PHP versions explicitly present in `playground.config.json`. That file contains curated PHP 8.3 runtime entries only, so selecting PHP 8.1, 8.2, 8.4, or 8.5 loaded an esbuild stub and failed with `PHP runtime not bundled in this build`.

## Validation

- confirmed the shared compatibility matrix exposes PHP 8.1 through PHP 8.5
- confirmed the generated keep list now follows that shared matrix instead of the curated runtime configuration
- CI should run the repository lint and test checks