### PR TITLE
fix(sw): restore admin CSS/JS by routing /application/asset/* to the PHP worker

### DIFF
--- a/src/shared/html-url-rewrite.js
+++ b/src/shared/html-url-rewrite.js
@@ -1,0 +1,183 @@
+/**
+ * Pure helpers for rewriting absolute URLs in Omeka HTML responses so they
+ * route through the scoped playground path (`/playground/<scope>/<runtime>/…`).
+ *
+ * Kept free of Service Worker globals so unit tests can import them.
+ */
+
+// Paths that live on the real static host (GitHub Pages / local dev server)
+// and must NOT be forwarded to the PHP/WASM worker. Omeka's own static assets
+// under `/application/asset/` are NOT listed here — they only exist inside the
+// readonly core bundle in MEMFS and must be routed to the worker (via scoped
+// URLs or referrer-based scoping). Adding them here made admin CSS/JS 404 on
+// GitHub Pages (regression from PR #120).
+export const HOST_STATIC_PREFIXES = [
+  "/assets/",
+  "/src/",
+  "/vendor/",
+  "/dist/",
+  "/sw.js",
+  "/remote.html",
+  "/index.html",
+  "/playground.config.json",
+  "/favicon.ico",
+];
+
+export function isHostStaticPath(pathname) {
+  const path = pathname || "/";
+  return HOST_STATIC_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(prefix),
+  );
+}
+
+export function escapeHtml(str) {
+  return String(str)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+const NAMED_HTML_ENTITIES = {
+  amp: "&",
+  quot: '"',
+  apos: "'",
+  sol: "/",
+  colon: ":",
+};
+
+export function decodeHtmlAttributeEntities(value) {
+  // Decode every entity in a single left-to-right pass. Doing it in one pass
+  // (rather than chained .replace/.replaceAll calls) prevents double-unescaping:
+  // a "&" produced by decoding one entity must not be reinterpreted as the
+  // start of another entity in a later pass.
+  return value.replace(/&(#x[0-9a-f]+|#[0-9]+|[a-z]+);/giu, (match, body) => {
+    const lower = body.toLowerCase();
+    if (lower.startsWith("#x")) {
+      return String.fromCodePoint(Number.parseInt(body.slice(2), 16));
+    }
+    if (lower.startsWith("#")) {
+      return String.fromCodePoint(Number.parseInt(body.slice(1), 10));
+    }
+    return Object.hasOwn(NAMED_HTML_ENTITIES, lower)
+      ? NAMED_HTML_ENTITIES[lower]
+      : match;
+  });
+}
+
+/**
+ * Rewrite one HTML attribute URL for a scoped Omeka response.
+ *
+ * @param {string} rawValue
+ * @param {{
+ *   origin: string,
+ *   scopeId: string,
+ *   runtimeId: string,
+ *   appBasePath?: string,
+ *   scopedBasePath?: string,
+ * }} options
+ *   `appBasePath` defaults to `"/"`. `scopedBasePath` defaults to
+ *   `${appBasePath}/playground/${scopeId}/${runtimeId}` (with base `/` handled).
+ */
+export function rewriteHtmlAttributeUrl(rawValue, options) {
+  const { origin, scopeId, runtimeId, appBasePath = "/" } = options;
+  const scopedBasePath =
+    options.scopedBasePath ??
+    (appBasePath === "/"
+      ? `/playground/${scopeId}/${runtimeId}`
+      : `${appBasePath}/playground/${scopeId}/${runtimeId}`
+    ).replace(/\/{2,}/gu, "/");
+
+  const decodedValue = decodeHtmlAttributeEntities(rawValue);
+
+  if (!decodedValue) {
+    return decodedValue;
+  }
+
+  // Leave fragment-only, protocol-relative, and special-scheme URLs untouched.
+  // Scheme matching is case-insensitive and covers every script-capable scheme
+  // (javascript:, vbscript:) so none of them slip through to be rewritten.
+  const lowerValue = decodedValue.toLowerCase();
+  if (
+    decodedValue.startsWith("#") ||
+    decodedValue.startsWith("//") ||
+    lowerValue.startsWith("javascript:") ||
+    lowerValue.startsWith("vbscript:") ||
+    lowerValue.startsWith("data:") ||
+    lowerValue.startsWith("mailto:") ||
+    lowerValue.startsWith("tel:")
+  ) {
+    return decodedValue;
+  }
+
+  // Skip relative URLs (not starting with "/") — they resolve correctly
+  // relative to the document's own URL and must not be rewritten.
+  if (!decodedValue.startsWith("/")) {
+    return decodedValue;
+  }
+
+  try {
+    const absolute = new URL(decodedValue, origin);
+    if (absolute.origin !== origin) {
+      return decodedValue;
+    }
+
+    const absolutePath = `${absolute.pathname}${absolute.search}${absolute.hash}`;
+    // Already under the scoped runtime path — leave alone.
+    if (
+      absolute.pathname.startsWith(`${scopedBasePath}/`) ||
+      absolute.pathname === scopedBasePath
+    ) {
+      return absolutePath;
+    }
+
+    // Strip the GitHub Pages / static-hosting app base (e.g. `/omeka-s-playground`)
+    // so we can decide whether this is a shell static asset or an Omeka path.
+    // Omeka's AssetUrl helper prefixes Laminas basePath(), so on GH Pages it
+    // emits `/omeka-s-playground/application/asset/...` rather than bare
+    // `/application/asset/...`. Those still need the playground scope so the
+    // worker can serve them from MEMFS — they must not be left as host-static.
+    let pathFromAppRoot = absolute.pathname;
+    if (
+      appBasePath !== "/" &&
+      (pathFromAppRoot === appBasePath ||
+        pathFromAppRoot.startsWith(`${appBasePath}/`))
+    ) {
+      pathFromAppRoot =
+        pathFromAppRoot === appBasePath
+          ? "/"
+          : pathFromAppRoot.slice(appBasePath.length) || "/";
+    }
+
+    // Shell/static assets on the real origin stay unscoped (samples, dist,
+    // source modules, etc.).
+    if (isHostStaticPath(pathFromAppRoot)) {
+      return absolutePath;
+    }
+
+    if (!pathFromAppRoot.startsWith("/")) {
+      return decodedValue;
+    }
+
+    return `${scopedBasePath}${pathFromAppRoot}${absolute.search}${absolute.hash}`.replace(
+      /\/{2,}/gu,
+      "/",
+    );
+  } catch {
+    return decodedValue;
+  }
+}
+
+export function rewriteHtmlDocument(html, scope) {
+  return html.replace(
+    /((?:href|src|action|data-[\w-]*url|data-url|data-action)=["'])([^"']*)(["'])/giu,
+    // rewriteHtmlAttributeUrl returns a *decoded* URL (entities turned back
+    // into raw &, ", <, > characters). Re-encode it for HTML attribute context
+    // before interpolating it back between the quotes, otherwise a decoded
+    // value containing a quote could close the attribute early and inject HTML
+    // into the playground iframe (reflected XSS).
+    (match, prefix, rawValue, suffix) =>
+      `${prefix}${escapeHtml(rewriteHtmlAttributeUrl(rawValue, scope))}${suffix}`,
+  );
+}

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,9 @@
 import { BUILD_VERSION } from "./src/generated/build-version.js";
+import {
+  isHostStaticPath,
+  rewriteHtmlAttributeUrl as rewriteHtmlAttributeUrlPure,
+  rewriteHtmlDocument as rewriteHtmlDocumentPure,
+} from "./src/shared/html-url-rewrite.js";
 import { createPhpBridgeChannel, createWorkerRequestId } from "./src/shared/protocol.js";
 
 const INTERNAL_PROXY_PATH = "/__playground_proxy__";
@@ -16,18 +21,6 @@ let playgroundConfigPromise;
 const bridges = new Map();
 const pending = new Map();
 const clientContexts = new Map();
-const STATIC_PREFIXES = [
-  "/assets/",
-  "/application/asset/",
-  "/src/",
-  "/vendor/",
-  "/dist/",
-  "/sw.js",
-  "/remote.html",
-  "/index.html",
-  "/playground.config.json",
-  "/favicon.ico",
-];
 
 function getAppBasePath() {
   const scopeUrl = new URL(self.registration.scope);
@@ -193,7 +186,10 @@ async function resolveScopedRequest(event, url) {
     };
   }
 
-  if (STATIC_PREFIXES.some((prefix) => strippedPathname === prefix || strippedPathname.startsWith(prefix))) {
+  // Host-static paths (shell assets, dist, etc.) pass through to the network.
+  // Omeka `/application/asset/*` is intentionally NOT host-static — see
+  // HOST_STATIC_PREFIXES in html-url-rewrite.js.
+  if (isHostStaticPath(strippedPathname)) {
     return null;
   }
 
@@ -275,111 +271,22 @@ function getScopedBasePath(scopeId, runtimeId) {
   return withAppBasePath(`/playground/${scopeId}/${runtimeId}`);
 }
 
-function escapeHtml(str) {
-  return String(str)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-const NAMED_HTML_ENTITIES = {
-  amp: "&",
-  quot: '"',
-  apos: "'",
-  sol: "/",
-  colon: ":",
-};
-
-function decodeHtmlAttributeEntities(value) {
-  // Decode every entity in a single left-to-right pass. Doing it in one pass
-  // (rather than chained .replace/.replaceAll calls) prevents double-unescaping:
-  // a "&" produced by decoding one entity must not be reinterpreted as the
-  // start of another entity in a later pass.
-  return value.replace(
-    /&(#x[0-9a-f]+|#[0-9]+|[a-z]+);/giu,
-    (match, body) => {
-      const lower = body.toLowerCase();
-      if (lower.startsWith("#x")) {
-        return String.fromCodePoint(Number.parseInt(body.slice(2), 16));
-      }
-      if (lower.startsWith("#")) {
-        return String.fromCodePoint(Number.parseInt(body.slice(1), 10));
-      }
-      return Object.hasOwn(NAMED_HTML_ENTITIES, lower)
-        ? NAMED_HTML_ENTITIES[lower]
-        : match;
-    },
-  );
-}
-
 function rewriteHtmlAttributeUrl(rawValue, { origin, scopeId, runtimeId }) {
-  const decodedValue = decodeHtmlAttributeEntities(rawValue);
-  const scopedBasePath = getScopedBasePath(scopeId, runtimeId);
-  const appBasePath = getAppBasePath();
-
-  if (!decodedValue) {
-    return decodedValue;
-  }
-
-  // Leave fragment-only, protocol-relative, and special-scheme URLs untouched.
-  // Scheme matching is case-insensitive and covers every script-capable scheme
-  // (javascript:, vbscript:) so none of them slip through to be rewritten.
-  const lowerValue = decodedValue.toLowerCase();
-  if (
-    decodedValue.startsWith("#")
-    || decodedValue.startsWith("//")
-    || lowerValue.startsWith("javascript:")
-    || lowerValue.startsWith("vbscript:")
-    || lowerValue.startsWith("data:")
-    || lowerValue.startsWith("mailto:")
-    || lowerValue.startsWith("tel:")
-  ) {
-    return decodedValue;
-  }
-
-  // Skip relative URLs (not starting with "/") — they resolve correctly
-  // relative to the document's own URL and must not be rewritten.
-  if (!decodedValue.startsWith("/")) {
-    return decodedValue;
-  }
-
-  try {
-    const absolute = new URL(decodedValue, origin);
-    if (absolute.origin !== origin) {
-      return decodedValue;
-    }
-
-    const absolutePath = `${absolute.pathname}${absolute.search}${absolute.hash}`;
-    if (absolute.pathname.startsWith(`${scopedBasePath}/`) || absolute.pathname === scopedBasePath) {
-      return absolutePath;
-    }
-
-    if (appBasePath !== "/" && (absolute.pathname === appBasePath || absolute.pathname.startsWith(`${appBasePath}/`))) {
-      return absolutePath;
-    }
-
-    if (!absolute.pathname.startsWith("/")) {
-      return decodedValue;
-    }
-
-    return `${scopedBasePath}${absolutePath.startsWith("/") ? absolutePath : `/${absolutePath}`}`.replace(/\/{2,}/gu, "/");
-  } catch {
-    return decodedValue;
-  }
+  return rewriteHtmlAttributeUrlPure(rawValue, {
+    origin,
+    scopeId,
+    runtimeId,
+    appBasePath: getAppBasePath(),
+    scopedBasePath: getScopedBasePath(scopeId, runtimeId),
+  });
 }
 
 function rewriteHtmlDocument(html, scope) {
-  return html.replace(
-    /((?:href|src|action|data-[\w-]*url|data-url|data-action)=["'])([^"']*)(["'])/giu,
-    // rewriteHtmlAttributeUrl returns a *decoded* URL (entities turned back
-    // into raw &, ", <, > characters). Re-encode it for HTML attribute context
-    // before interpolating it back between the quotes, otherwise a decoded
-    // value containing a quote could close the attribute early and inject HTML
-    // into the playground iframe (reflected XSS).
-    (match, prefix, rawValue, suffix) => `${prefix}${escapeHtml(rewriteHtmlAttributeUrl(rawValue, scope))}${suffix}`,
-  );
+  return rewriteHtmlDocumentPure(html, {
+    ...scope,
+    appBasePath: getAppBasePath(),
+    scopedBasePath: getScopedBasePath(scope.scopeId, scope.runtimeId),
+  });
 }
 
 async function rewriteScopedHtmlResponse(response, scope) {

--- a/tests/html-url-rewrite.test.mjs
+++ b/tests/html-url-rewrite.test.mjs
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  HOST_STATIC_PREFIXES,
+  isHostStaticPath,
+  rewriteHtmlAttributeUrl,
+  rewriteHtmlDocument,
+} from "../src/shared/html-url-rewrite.js";
+
+const ORIGIN = "https://ateeducacion.github.io";
+const APP_BASE = "/omeka-s-playground";
+const SCOPE = {
+  origin: ORIGIN,
+  scopeId: "scope-1",
+  runtimeId: "php83-omeka421",
+  appBasePath: APP_BASE,
+};
+
+const SCOPED = "/omeka-s-playground/playground/scope-1/php83-omeka421";
+
+describe("isHostStaticPath", () => {
+  it("treats playground shell assets as host-static", () => {
+    assert.equal(isHostStaticPath("/assets/samples/foo.png"), true);
+    assert.equal(isHostStaticPath("/dist/php-worker.bundle.js"), true);
+    assert.equal(isHostStaticPath("/src/shell/main.js"), true);
+    assert.equal(isHostStaticPath("/favicon.ico"), true);
+  });
+
+  it("does NOT treat Omeka application assets as host-static (PR #120 regression)", () => {
+    // This was the production bug: listing /application/asset/ as host-static
+    // made the service worker fetch CSS/JS from GitHub Pages (404) instead of
+    // routing them to the PHP/WASM worker that serves them from MEMFS.
+    assert.equal(isHostStaticPath("/application/asset/css/style.css"), false);
+    assert.equal(
+      isHostStaticPath("/application/asset/vendor/jquery/jquery.min.js"),
+      false,
+    );
+    assert.ok(
+      !HOST_STATIC_PREFIXES.includes("/application/asset/"),
+      "HOST_STATIC_PREFIXES must not include /application/asset/",
+    );
+  });
+});
+
+describe("rewriteHtmlAttributeUrl — GitHub Pages base path", () => {
+  it("scopes bare Omeka asset paths into the playground runtime", () => {
+    assert.equal(
+      rewriteHtmlAttributeUrl("/application/asset/css/style.css", SCOPE),
+      `${SCOPED}/application/asset/css/style.css`,
+    );
+  });
+
+  it("scopes Omeka AssetUrl paths that already include the app base path", () => {
+    // Omeka's AssetUrl uses Laminas basePath(), so on GH Pages it emits
+    // `/omeka-s-playground/application/asset/...`. The previous rewrite left
+    // those unscoped, and with /application/asset/ in STATIC_PREFIXES the SW
+    // then 404'd them from the real host.
+    assert.equal(
+      rewriteHtmlAttributeUrl(
+        "/omeka-s-playground/application/asset/css/style.css?v=4.2.1",
+        SCOPE,
+      ),
+      `${SCOPED}/application/asset/css/style.css?v=4.2.1`,
+    );
+    assert.equal(
+      rewriteHtmlAttributeUrl(
+        "/omeka-s-playground/application/asset/vendor/tablesaw/tablesaw.stackonly.css",
+        SCOPE,
+      ),
+      `${SCOPED}/application/asset/vendor/tablesaw/tablesaw.stackonly.css`,
+    );
+  });
+
+  it("scopes admin and other Omeka app routes that include the app base", () => {
+    assert.equal(
+      rewriteHtmlAttributeUrl("/omeka-s-playground/admin", SCOPE),
+      `${SCOPED}/admin`,
+    );
+    assert.equal(
+      rewriteHtmlAttributeUrl("/omeka-s-playground/admin/item", SCOPE),
+      `${SCOPED}/admin/item`,
+    );
+  });
+
+  it("leaves already-scoped runtime paths alone", () => {
+    const already = `${SCOPED}/application/asset/css/style.css`;
+    assert.equal(rewriteHtmlAttributeUrl(already, SCOPE), already);
+  });
+
+  it("leaves shell/static sample assets unscoped", () => {
+    assert.equal(
+      rewriteHtmlAttributeUrl(
+        "/omeka-s-playground/assets/samples/garden-of-earthly-delights.png",
+        SCOPE,
+      ),
+      "/omeka-s-playground/assets/samples/garden-of-earthly-delights.png",
+    );
+    assert.equal(
+      rewriteHtmlAttributeUrl("/omeka-s-playground/dist/php_8_3.wasm", SCOPE),
+      "/omeka-s-playground/dist/php_8_3.wasm",
+    );
+  });
+
+  it("leaves relative and special-scheme URLs alone", () => {
+    assert.equal(
+      rewriteHtmlAttributeUrl("css/style.css", SCOPE),
+      "css/style.css",
+    );
+    assert.equal(rewriteHtmlAttributeUrl("#main", SCOPE), "#main");
+    assert.equal(
+      rewriteHtmlAttributeUrl("javascript:void(0)", SCOPE),
+      "javascript:void(0)",
+    );
+    assert.equal(
+      rewriteHtmlAttributeUrl("mailto:admin@example.com", SCOPE),
+      "mailto:admin@example.com",
+    );
+  });
+
+  it("works at site root without an app base path", () => {
+    const local = {
+      origin: "http://127.0.0.1:8080",
+      scopeId: "scope-1",
+      runtimeId: "php83-omeka421",
+      appBasePath: "/",
+    };
+    assert.equal(
+      rewriteHtmlAttributeUrl("/application/asset/css/style.css", local),
+      "/playground/scope-1/php83-omeka421/application/asset/css/style.css",
+    );
+  });
+});
+
+describe("rewriteHtmlDocument", () => {
+  it("rewrites href/src attributes for Omeka assets under the app base", () => {
+    const html = [
+      '<link rel="stylesheet" href="/omeka-s-playground/application/asset/css/style.css">',
+      '<script src="/omeka-s-playground/application/asset/js/admin.js"></script>',
+      '<a href="/omeka-s-playground/admin/item">Items</a>',
+      '<img src="/omeka-s-playground/assets/samples/foo.png" alt="">',
+    ].join("\n");
+
+    const out = rewriteHtmlDocument(html, SCOPE);
+
+    assert.match(
+      out,
+      new RegExp(
+        `href="${SCOPED}/application/asset/css/style\\.css"`.replaceAll(
+          "/",
+          "\\/",
+        ),
+      ),
+    );
+    assert.match(
+      out,
+      new RegExp(
+        `src="${SCOPED}/application/asset/js/admin\\.js"`.replaceAll(
+          "/",
+          "\\/",
+        ),
+      ),
+    );
+    assert.match(
+      out,
+      new RegExp(`href="${SCOPED}/admin/item"`.replaceAll("/", "\\/")),
+    );
+    // Shell sample stays on the static host.
+    assert.match(out, /src="\/omeka-s-playground\/assets\/samples\/foo\.png"/);
+  });
+
+  it("handles HTML-escaped asset paths from Omeka", () => {
+    const html =
+      '<link href="&#x2F;omeka-s-playground&#x2F;application&#x2F;asset&#x2F;css&#x2F;style.css">';
+    const out = rewriteHtmlDocument(html, SCOPE);
+    assert.match(
+      out,
+      new RegExp(
+        `href="${SCOPED}/application/asset/css/style\\.css"`.replaceAll(
+          "/",
+          "\\/",
+        ),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause:** PR #120 added `/application/asset/` to the service worker's host-static prefix list. Omeka admin CSS/JS only exist inside the readonly core bundle in MEMFS, not on GitHub Pages, so requests returned **404** and the admin UI rendered unstyled (as on https://ateeducacion.github.io/omeka-s-playground/).
- **Second issue:** Omeka's `AssetUrl` helper prefixes Laminas `basePath()`, so on GH Pages it emits `/omeka-s-playground/application/asset/...`. The HTML rewriter left any path under the app base unscoped, so even after removing the bad prefix the links still relied on fragile referrer-based routing.
- **Fix:** Drop `/application/asset/` from host-static prefixes, rewrite Omeka app-base-prefixed paths into the scoped playground runtime (while leaving real shell static paths like `/assets/`, `/dist/` on the host), and extract pure helpers with regression tests.

## Console symptoms (before)

```
tablesaw.stackonly.css:1  Failed to load resource: 404
iconfonts.css:1  Failed to load resource: 404
style.css:1  Failed to load resource: 404
jquery.min.js / admin.js / global.js … 404
Uncaught ReferenceError: Omeka is not defined / $ is not defined
```

## Test plan

- [x] `node --test tests/html-url-rewrite.test.mjs` (11 cases, including the PR #120 regression)
- [x] `make test` (full unit suite)
- [x] `make lint` (no new errors)
- [ ] After deploy: open https://ateeducacion.github.io/omeka-s-playground/ (hard refresh / unregister old SW if needed)
- [ ] Confirm admin dashboard has default Omeka styling (maroon header, icons)
- [ ] Network: `/application/asset/css/style.css` (scoped under `/playground/<scope>/<runtime>/…`) returns 200 from the worker, not a GH Pages 404
- [ ] Local: `make serve` and verify the same at `/admin`