### PR TITLE
Prevent fork pull requests from running playground workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -43,6 +44,7 @@ jobs:
   # runs `make bundle` (git clone + composer + runtime) then `make serve`;
   # ubuntu-latest ships php + composer.
   e2e:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/cloudflare-pages-cleanup.yml
+++ b/.github/workflows/cloudflare-pages-cleanup.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   cleanup:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       HAS_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}


### PR DESCRIPTION
## Summary

- skip unit, lint, and Playwright jobs for pull requests originating from forks
- skip the Cloudflare cleanup workflow for fork pull requests
- preserve pushes, manual cleanup runs, and same-repository pull requests

## Security rationale

These workflows install npm and browser dependencies, build Omeka bundles, upload artifacts, and include pull-request write access plus optional Cloudflare credentials. Restricting fork-originated jobs prevents untrusted code from consuming substantial runner resources or reaching write-capable cleanup logic.