### PR TITLE
Redesign shell toolbar and side panel (Shell UI v2)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ At runtime:
 - the Omeka core is extracted from a ZIP bundle into writable MEMFS under `/www/omeka`
 - mutable state (SQLite database, config, uploads) lives under `/persist` in MEMFS
 - all state is ephemeral — closing the tab destroys everything
-- the shell hosts the running site in an iframe and exposes Home, Admin, and Docs navigation
+- the shell hosts the running site in an iframe and exposes Back, Refresh, and Home navigation plus Admin and Docs links
 - the service worker rewrites paths so the app works both locally and under the GitHub Pages subpath `/omeka-s-playground`
 - crash recovery snapshots the DB and addon files before WASM crashes and restores them onto fresh runtimes
 

--- a/index.html
+++ b/index.html
@@ -41,14 +41,26 @@
   <body data-app="shell">
     <div class="shell">
       <header class="browser-toolbar" aria-label="Playground toolbar">
-        <div class="browser-toolbar__address">
+        <div class="toolbar-brand" aria-label="Omeka S Playground">
+          <img class="toolbar-brand__logo" src="./logo.png" alt="Omeka S Playground">
+        </div>
+        <div class="browser-toolbar__center">
           <form id="address-form" class="address-form">
-            <div class="toolbar-brand" aria-label="Omeka S Playground">
-              <img class="toolbar-brand__logo" src="./logo.png" alt="Omeka S Playground">
+            <div class="nav-buttons">
+              <button type="button" id="back-button" class="icon-button" aria-label="Go back" title="Back" disabled>
+                <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <path d="M10 3 5 8l5 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+              <button type="button" id="refresh-button" class="icon-button" aria-label="Refresh page" title="Refresh page">
+                <span aria-hidden="true">&#8635;</span>
+              </button>
+              <button type="button" id="home-button" class="icon-button" aria-label="Go to site home page" title="Go to site home page">
+                <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <path d="M2.5 6.5V14h4v-4h3v4h4V6.5L8 2 2.5 6.5Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" fill="none"/>
+                </svg>
+              </button>
             </div>
-            <button type="button" id="refresh-button" class="icon-button" aria-label="Refresh page" title="Refresh page">
-              <span aria-hidden="true">&#8635;</span>
-            </button>
             <div class="address-form__input">
               <input id="address-input" type="text" spellcheck="false" value="/" aria-label="URL inside the Omeka site">
             </div>
@@ -56,20 +68,39 @@
           </form>
         </div>
         <div class="browser-toolbar__actions">
-          <button type="button" id="home-button" class="toolbar-link" title="Go to site home page">Home</button>
-          <button type="button" id="admin-button" class="toolbar-link" title="Go to admin panel">Admin</button>
+          <button type="button" id="admin-button" class="icon-button icon-button--labeled" aria-label="Go to admin panel" title="Go to admin panel">
+            <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
+              <rect x="9" y="2" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
+              <rect x="2" y="9" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
+              <rect x="9" y="9" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
+            </svg>
+            <span class="icon-button__label">Admin</span>
+          </button>
           <a href="docs/" class="icon-button icon-button--labeled" aria-label="Documentation" title="Documentation" target="_blank" rel="noreferrer">
-            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true" focusable="false">
+            <svg width="16" height="16" viewBox="0 0 18 18" fill="none" aria-hidden="true" focusable="false">
               <path d="M3 2.5A1.5 1.5 0 0 1 4.5 1h6.586a1 1 0 0 1 .707.293l3.414 3.414a1 1 0 0 1 .293.707V15.5A1.5 1.5 0 0 1 14 17H4.5A1.5 1.5 0 0 1 3 15.5v-13Z" stroke="currentColor" stroke-width="1.4" fill="none"/>
               <path d="M6 9h6M6 12h4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
-              <path d="M11 1v3.5a1 1 0 0 0 1 1h3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/>
             </svg>
             <span class="icon-button__label">Docs</span>
           </a>
+          <a
+            href="https://github.com/ateeducacion/omeka-s-playground"
+            class="icon-button"
+            aria-label="GitHub repository"
+            title="GitHub repository"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M8 0C3.58 0 0 3.67 0 8.2c0 3.63 2.29 6.71 5.47 7.8.4.08.55-.18.55-.4 0-.2-.01-.87-.01-1.58-2.01.38-2.53-.5-2.69-.96-.09-.24-.48-.97-.82-1.17-.28-.15-.68-.53-.01-.54.63-.01 1.08.59 1.23.84.72 1.24 1.87.89 2.33.68.07-.54.28-.89.51-1.09-1.78-.21-3.64-.92-3.64-4.08 0-.9.31-1.64.82-2.22-.08-.21-.36-1.06.08-2.2 0 0 .67-.22 2.2.85a7.38 7.38 0 0 1 4 0c1.53-1.07 2.2-.85 2.2-.85.44 1.14.16 1.99.08 2.2.51.58.82 1.31.82 2.22 0 3.17-1.87 3.87-3.65 4.08.29.26.54.75.54 1.52 0 1.1-.01 1.99-.01 2.26 0 .22.15.49.55.4A8.18 8.18 0 0 0 16 8.2C16 3.67 12.42 0 8 0Z"/>
+            </svg>
+          </a>
+          <span class="toolbar-separator" aria-hidden="true"></span>
           <button type="button" id="panel-toggle-button" class="icon-button" aria-label="Toggle sidebar panel" aria-expanded="false" title="Toggle sidebar">
-            <svg width="18" height="16" viewBox="0 0 18 16" fill="none" aria-hidden="true" focusable="false">
-              <rect x="0.5" y="0.5" width="10" height="15" rx="2" stroke="currentColor" stroke-width="1.5" fill="none"/>
-              <rect x="13" y="0.5" width="4.5" height="15" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+            <svg width="17" height="15" viewBox="0 0 18 16" fill="none" aria-hidden="true" focusable="false">
+              <rect x="0.75" y="0.75" width="16.5" height="14.5" rx="2.25" stroke="currentColor" stroke-width="1.5" fill="none"/>
+              <path d="M11.5 1v14" stroke="currentColor" stroke-width="1.5"/>
             </svg>
           </button>
         </div>
@@ -82,16 +113,17 @@
 
         <aside id="side-panel" class="side-panel is-collapsed" aria-label="Playground panel">
           <div class="side-panel__header">
-            <div>
-              <strong>Omeka S Playground</strong>
-              <span>Browser runtime controls</span>
+            <div class="side-panel__title">
+              <strong>Runtime</strong>
+              <span id="config-status" class="status-pill"><span class="dot"></span>Running</span>
             </div>
+            <button type="button" id="panel-close-button" class="side-panel__close" aria-label="Close panel" title="Close panel">&#10005;</button>
           </div>
 
           <div class="panel-tabs" role="tablist" aria-label="Playground panel tabs">
             <button type="button" id="info-tab" class="panel-tab is-active" role="tab" aria-selected="true" data-panel-tab="info">Info</button>
             <button type="button" id="logs-tab" class="panel-tab" role="tab" aria-selected="false" data-panel-tab="logs">Logs</button>
-            <button type="button" id="phpinfo-tab" class="panel-tab" role="tab" aria-selected="false" data-panel-tab="phpinfo">PHP Info</button>
+            <button type="button" id="phpinfo-tab" class="panel-tab" role="tab" aria-selected="false" data-panel-tab="phpinfo">PHP</button>
             <button type="button" id="blueprint-tab" class="panel-tab" role="tab" aria-selected="false" data-panel-tab="blueprint">Blueprint</button>
           </div>
 
@@ -100,15 +132,16 @@
               <div class="info-section">
                 <div class="section-label">
                   <span>Configuration</span>
-                  <span id="config-status" class="status-pill"><span class="dot"></span>Running</span>
                 </div>
-                <div class="field">
-                  <label for="info-omeka-version">Omeka version</label>
-                  <select id="info-omeka-version"></select>
-                </div>
-                <div class="field">
-                  <label for="info-php-version">PHP version</label>
-                  <select id="info-php-version"></select>
+                <div class="config-grid">
+                  <div class="field">
+                    <label for="info-omeka-version">Omeka</label>
+                    <select id="info-omeka-version"></select>
+                  </div>
+                  <div class="field">
+                    <label for="info-php-version">PHP</label>
+                    <select id="info-php-version"></select>
+                  </div>
                 </div>
                 <div id="config-warning" class="warn-banner is-hidden" role="alert">
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
@@ -123,8 +156,6 @@
                 </div>
               </div>
 
-              <hr class="divider">
-
               <div class="info-section">
                 <div class="section-label"><span>Runtime</span></div>
                 <div class="value-row">
@@ -137,6 +168,9 @@
                     </svg>
                   </button>
                 </div>
+              </div>
+
+              <div class="info-section info-section--bottom">
                 <div class="action-row">
                   <button type="button" id="reset-button" class="danger grow">Reset Playground</button>
                 </div>
@@ -149,8 +183,19 @@
             <div class="panel__row">
               <span>Runtime log</span>
               <span class="panel__row-actions">
-                <button type="button" id="copy-logs-button">Copy</button>
-                <button type="button" id="clear-logs-button">Clear</button>
+                <button type="button" id="copy-logs-button" class="bp-btn bp-btn--icon-only" title="Copy logs" aria-label="Copy logs">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <rect x="5" y="5" width="8" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
+                    <path d="M11 5V3.5A1.5 1.5 0 0 0 9.5 2h-5A1.5 1.5 0 0 0 3 3.5v7A1.5 1.5 0 0 0 4.5 12H5" stroke="currentColor" stroke-width="1.3" fill="none"/>
+                  </svg>
+                </button>
+                <button type="button" id="clear-logs-button" class="bp-btn bp-btn--icon-only" title="Clear logs" aria-label="Clear logs">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M2.5 4h11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+                    <path d="M5.5 4V2.75A.75.75 0 0 1 6.25 2h3.5a.75.75 0 0 1 .75.75V4" stroke="currentColor" stroke-width="1.3"/>
+                    <path d="M4.5 4l.55 9.3a.7.7 0 0 0 .7.66h4.5a.7.7 0 0 0 .7-.66L11.5 4" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
+                  </svg>
+                </button>
               </span>
             </div>
             <pre id="log-panel" class="log-panel"></pre>
@@ -159,21 +204,27 @@
           <section id="phpinfo-panel" class="side-panel__content side-panel__content--stack is-hidden" role="tabpanel" aria-labelledby="phpinfo-tab" data-panel-view="phpinfo">
             <div class="panel__row">
               <span>Runtime PHP Info</span>
-              <button type="button" id="refresh-phpinfo-button">Refresh</button>
+              <span class="panel__row-actions">
+                <button type="button" id="refresh-phpinfo-button" class="bp-btn bp-btn--icon-only" title="Refresh PHP info" aria-label="Refresh PHP info">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                    <path d="M13.5 1.5v3h-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+              </span>
             </div>
             <iframe id="phpinfo-frame" class="panel-frame" title="PHP Info diagnostics"></iframe>
           </section>
 
           <section id="blueprint-panel" class="side-panel__content side-panel__content--stack is-hidden" role="tabpanel" aria-labelledby="blueprint-tab" data-panel-view="blueprint">
             <div class="panel__row">
-              <span>Blueprint JSON</span>
+              <button type="button" id="run-button" class="bp-btn bp-btn--primary bp-btn--wide" title="Run blueprint" disabled>
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false">
+                  <path d="M4 2.5v11l10-5.5-10-5.5Z"/>
+                </svg>
+                <span>Run</span>
+              </button>
               <span class="panel__row-actions">
-                <button type="button" id="run-button" class="bp-btn bp-btn--primary bp-btn--wide" title="Run blueprint" disabled>
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false">
-                    <path d="M4 2.5v11l10-5.5-10-5.5Z"/>
-                  </svg>
-                  <span>Run</span>
-                </button>
                 <button type="button" id="export-button" class="bp-btn bp-btn--icon-only" title="Export blueprint JSON" aria-label="Export blueprint JSON">
                   <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
                     <path d="M8 2v7m0 0L5 6m3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
@@ -218,7 +269,9 @@
           </section>
 
           <footer class="side-panel__footer">
-            <p>Made with &#10084;&#65039; by <a href="https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/" target="_blank" rel="noreferrer">Área de Tecnología Educativa</a></p>
+            <div class="side-panel__footer-text">
+              <p>Made with &#10084;&#65039; by <a href="https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/" target="_blank" rel="noreferrer">Área de Tecnología Educativa</a></p>
+            </div>
             <a
               class="side-panel__footer-link"
               href="https://github.com/ateeducacion/omeka-s-playground"
@@ -233,7 +286,6 @@
                   d="M8 0C3.58 0 0 3.67 0 8.2c0 3.63 2.29 6.71 5.47 7.8.4.08.55-.18.55-.4 0-.2-.01-.87-.01-1.58-2.01.38-2.53-.5-2.69-.96-.09-.24-.48-.97-.82-1.17-.28-.15-.68-.53-.01-.54.63-.01 1.08.59 1.23.84.72 1.24 1.87.89 2.33.68.07-.54.28-.89.51-1.09-1.78-.21-3.64-.92-3.64-4.08 0-.9.31-1.64.82-2.22-.08-.21-.36-1.06.08-2.2 0 0 .67-.22 2.2.85a7.38 7.38 0 0 1 4 0c1.53-1.07 2.2-.85 2.2-.85.44 1.14.16 1.99.08 2.2.51.58.82 1.31.82 2.22 0 3.17-1.87 3.87-3.65 4.08.29.26.54.75.54 1.52 0 1.1-.01 1.99-.01 2.26 0 .22.15.49.55.4A8.18 8.18 0 0 0 16 8.2C16 3.67 12.42 0 8 0Z"
                 />
               </svg>
-              <span>GitHub</span>
             </a>
           </footer>
         </aside>

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
       <header class="browser-toolbar" aria-label="Playground toolbar">
         <div class="toolbar-brand" aria-label="Omeka S Playground">
           <img class="toolbar-brand__logo" src="./logo.png" alt="Omeka S Playground">
+          <img class="toolbar-brand__icon" src="./favicon.ico" alt="Omeka S Playground">
         </div>
         <div class="browser-toolbar__center">
           <form id="address-form" class="address-form">
@@ -85,7 +86,7 @@
           </a>
           <a
             href="https://github.com/ateeducacion/omeka-s-playground"
-            class="icon-button"
+            class="icon-button toolbar-github"
             aria-label="GitHub repository"
             title="GitHub repository"
             target="_blank"

--- a/index.html
+++ b/index.html
@@ -55,9 +55,17 @@
               <button type="button" id="refresh-button" class="icon-button" aria-label="Refresh page" title="Refresh page">
                 <span aria-hidden="true">&#8635;</span>
               </button>
-              <button type="button" id="home-button" class="icon-button" aria-label="Go to site home page" title="Go to site home page">
+              <button type="button" id="home-button" class="icon-button" aria-label="Go to site home page" title="Home">
                 <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
                   <path d="M2.5 6.5V14h4v-4h3v4h4V6.5L8 2 2.5 6.5Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" fill="none"/>
+                </svg>
+              </button>
+              <button type="button" id="admin-button" class="icon-button" aria-label="Go to admin panel" title="Admin">
+                <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <rect x="2" y="2" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
+                  <rect x="9" y="2" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
+                  <rect x="2" y="9" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
+                  <rect x="9" y="9" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
                 </svg>
               </button>
             </div>
@@ -68,15 +76,6 @@
           </form>
         </div>
         <div class="browser-toolbar__actions">
-          <button type="button" id="admin-button" class="icon-button icon-button--labeled" aria-label="Go to admin panel" title="Go to admin panel">
-            <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
-              <rect x="2" y="2" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
-              <rect x="9" y="2" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
-              <rect x="2" y="9" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
-              <rect x="9" y="9" width="5" height="5" rx="1.2" stroke="currentColor" stroke-width="1.4"/>
-            </svg>
-            <span class="icon-button__label">Admin</span>
-          </button>
           <a href="docs/" class="icon-button icon-button--labeled" aria-label="Documentation" title="Documentation" target="_blank" rel="noreferrer">
             <svg width="16" height="16" viewBox="0 0 18 18" fill="none" aria-hidden="true" focusable="false">
               <path d="M3 2.5A1.5 1.5 0 0 1 4.5 1h6.586a1 1 0 0 1 .707.293l3.414 3.414a1 1 0 0 1 .293.707V15.5A1.5 1.5 0 0 1 14 17H4.5A1.5 1.5 0 0 1 3 15.5v-13Z" stroke="currentColor" stroke-width="1.4" fill="none"/>

--- a/src/shell/blueprint-editor-core.js
+++ b/src/shell/blueprint-editor-core.js
@@ -160,7 +160,9 @@ export function createBlueprintValidationResult(rawText, deps) {
   return {
     valid: true,
     stage: "valid",
-    message: "Blueprint is valid.",
+    // No step count (unlike moodle-playground): blueprints here are declarative
+    // sections, not an ordered step list.
+    message: "✓ Valid blueprint",
     blueprint,
   };
 }

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -399,13 +399,24 @@ function bindShellChannel() {
         setUiLocked(true);
         appendLog(`${message.title}: ${message.detail}`);
         break;
-      case "ready":
+      case "ready": {
+        // The remote frame emits "ready" before "navigate" on every iframe
+        // load, so in-site navigations have to be recorded here: by the time
+        // "navigate" arrives currentPath has already moved on and there is no
+        // transition left to push. The first load is the landing redirect, not
+        // a user navigation, so it is skipped.
+        const wasBooted = remoteFrameBooted;
         remoteFrameBooted = true;
         setUiLocked(false);
-        currentPath = message.path || currentPath;
+        const nextPath = message.path || currentPath;
+        if (wasBooted) {
+          recordBackEntry(currentPath, nextPath);
+        }
+        currentPath = nextPath;
         els.address.value = currentPath;
         saveState({ lastReadyAt: new Date().toISOString() });
         break;
+      }
       case "navigate": {
         const nextPath = message.path || "/";
         recordBackEntry(currentPath, nextPath);

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -48,11 +48,13 @@ const els = {
   logPanel: document.querySelector("#log-panel"),
   logsPanel: document.querySelector("#logs-panel"),
   logsTab: document.querySelector("#logs-tab"),
+  panelClose: document.querySelector("#panel-close-button"),
   panelToggle: document.querySelector("#panel-toggle-button"),
   phpInfoFrame: document.querySelector("#phpinfo-frame"),
   phpInfoPanel: document.querySelector("#phpinfo-panel"),
   phpInfoTab: document.querySelector("#phpinfo-tab"),
   refreshPhpInfoButton: document.querySelector("#refresh-phpinfo-button"),
+  back: document.querySelector("#back-button"),
   refresh: document.querySelector("#refresh-button"),
   homeButton: document.querySelector("#home-button"),
   adminButton: document.querySelector("#admin-button"),
@@ -86,6 +88,11 @@ let currentRuntimeId;
 let currentPhpVersion = DEFAULT_PHP_VERSION;
 let currentOmekaVersion = DEFAULT_OMEKA_VERSION;
 let currentPath = "/";
+// In-shell navigation history for the toolbar Back button. The iframe's own
+// session history is not usable here (navigations happen across nested frames
+// and service-worker scopes), so the shell tracks visited paths itself.
+const backStack = [];
+let suppressBackPush = false;
 let channel;
 let serviceWorkerReady = null;
 let activeBlueprint;
@@ -118,6 +125,24 @@ function setUiLocked(locked) {
   els.importInput.disabled = locked;
   els.addressForm.classList.toggle("is-disabled", locked);
   blueprintEditor.setLocked(locked);
+  updateBackButton();
+}
+
+function updateBackButton() {
+  if (els.back) {
+    els.back.disabled = uiLocked || backStack.length === 0;
+  }
+}
+
+function recordBackEntry(previousPath, nextPath) {
+  const suppressed = suppressBackPush;
+  suppressBackPush = false;
+  if (!suppressed && previousPath && previousPath !== nextPath) {
+    if (backStack[backStack.length - 1] !== previousPath) {
+      backStack.push(previousPath);
+    }
+  }
+  updateBackButton();
 }
 
 async function ensureRuntimeServiceWorker() {
@@ -185,7 +210,9 @@ function navigateWithinRuntime(path) {
     return;
   }
 
+  const previousPath = currentPath;
   currentPath = path || "/";
+  recordBackEntry(previousPath, currentPath);
   els.address.value = currentPath;
   saveState();
 
@@ -379,11 +406,14 @@ function bindShellChannel() {
         els.address.value = currentPath;
         saveState({ lastReadyAt: new Date().toISOString() });
         break;
-      case "navigate":
-        currentPath = message.path || "/";
+      case "navigate": {
+        const nextPath = message.path || "/";
+        recordBackEntry(currentPath, nextPath);
+        currentPath = nextPath;
         els.address.value = currentPath;
         saveState();
         break;
+      }
       case "error":
         remoteFrameBooted = false;
         setUiLocked(false);
@@ -608,6 +638,16 @@ async function main() {
   await updateFrame();
 }
 
+els.back.addEventListener("click", () => {
+  if (uiLocked || backStack.length === 0) {
+    return;
+  }
+  const previousPath = backStack.pop();
+  updateBackButton();
+  suppressBackPush = true;
+  navigateWithinRuntime(previousPath);
+});
+
 els.refresh.addEventListener("click", () => {
   navigateWithinRuntime(currentPath);
 });
@@ -615,6 +655,11 @@ els.refresh.addEventListener("click", () => {
 els.homeButton.addEventListener("click", navigateHome);
 els.adminButton.addEventListener("click", navigateAdmin);
 els.panelToggle.addEventListener("click", toggleSidePanel);
+els.panelClose.addEventListener("click", () => {
+  if (!els.sidePanel.classList.contains("is-collapsed")) {
+    toggleSidePanel();
+  }
+});
 els.infoTab.addEventListener("click", () => setActivePanel("info"));
 els.logsTab.addEventListener("click", () => setActivePanel("logs"));
 els.phpInfoTab.addEventListener("click", () => {
@@ -628,10 +673,11 @@ els.clearLogs.addEventListener("click", () => {
 els.copyLogs.addEventListener("click", () => {
   const text = els.logPanel.textContent || "";
   navigator.clipboard.writeText(text).then(() => {
-    const original = els.copyLogs.textContent;
-    els.copyLogs.textContent = "Copied!";
+    // Icon-only button: swap the SVG for a checkmark, then restore it.
+    const original = els.copyLogs.innerHTML;
+    els.copyLogs.textContent = "✓";
     setTimeout(() => {
-      els.copyLogs.textContent = original;
+      els.copyLogs.innerHTML = original;
     }, 1200);
   });
 });
@@ -681,6 +727,8 @@ els.reset.addEventListener("click", () => {
     updateBlueprintTextarea();
   }
   currentPath = activeBlueprint?.landingPage || config.landingPath || "/";
+  backStack.length = 0;
+  updateBackButton();
   els.address.value = currentPath;
   pendingCleanBoot = true;
   remoteFrameBooted = false;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -961,13 +961,18 @@ button.danger:hover {
     grid-template-columns: 1fr;
   }
 
-  .workspace:not(.is-panel-collapsed) {
-    grid-template-rows: 1fr 1fr;
-  }
-
+  /* On narrow screens the open panel takes over the whole area below the
+     toolbar instead of splitting the screen with the site. */
   .side-panel {
+    position: fixed;
+    top: var(--navbar-height);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 15;
     border-left: 0;
     border-top: 1px solid var(--border-light);
+    box-shadow: none;
   }
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -986,8 +986,7 @@ button.danger:hover {
     display: none;
   }
 
-  .toolbar-separator,
-  #admin-button {
+  .toolbar-separator {
     display: none;
   }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21,17 +21,19 @@
   --color-maroon-light: rgba(130, 36, 51, 0.08);
   --color-maroon-border: rgba(130, 36, 51, 0.25);
 
-  /* Chrome (navbar + sidebar) on-maroon palette */
-  --chrome-bg: var(--color-maroon-soft);
+  /* Chrome (navbar) on-maroon palette */
+  --chrome-bg: #ab364b;
+  --chrome-bg2: var(--color-maroon-soft);
   --chrome-text: #ffffff;
-  --chrome-text-muted: rgba(255, 255, 255, 0.8);
-  --chrome-border: rgba(255, 255, 255, 0.2);
-  --chrome-hover: rgba(255, 255, 255, 0.15);
-  --chrome-active: rgba(255, 255, 255, 0.25);
+  --chrome-text-muted: rgba(255, 255, 255, 0.82);
+  --chrome-border: rgba(255, 255, 255, 0.22);
+  --chrome-hover: rgba(255, 255, 255, 0.16);
+  --chrome-input: rgba(255, 255, 255, 0.18);
+  --chrome-cluster: rgba(0, 0, 0, 0.08);
   --color-danger: #dc3545;
   --color-danger-hover: #c82333;
   --color-danger-light: rgba(220, 53, 69, 0.08);
-  --color-danger-border: rgba(220, 53, 69, 0.25);
+  --color-danger-border: rgba(220, 53, 69, 0.35);
   --color-success: #2f9e44;
 
   /* Semantic */
@@ -66,7 +68,7 @@
   --shadow-popover: 0 10px 32px rgba(0, 0, 0, 0.14);
 
   /* Layout */
-  --navbar-height: 56px;
+  --navbar-height: 54px;
   --sidebar-width: 340px;
 }
 
@@ -132,13 +134,16 @@ a:focus-visible {
 }
 
 button.danger {
-  color: var(--color-white);
-  background: var(--color-danger);
-  border-color: transparent;
+  color: var(--color-danger);
+  background: var(--bg-surface);
+  border-color: var(--color-danger-border);
+  font-weight: 600;
 }
 
 button.danger:hover {
-  background: var(--color-danger-hover);
+  color: var(--color-white);
+  background: var(--color-danger);
+  border-color: var(--color-danger);
 }
 
 /* -- Shell layout ------------------------------------------ */
@@ -158,20 +163,23 @@ button.danger:hover {
   right: 0;
   z-index: 20;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--space-md);
+  /* The centre column never goes below the nav cluster's width, so the wide
+     brand wordmark scales down instead of pushing it under the actions. */
+  grid-template-columns: auto minmax(min-content, 1fr) auto;
+  gap: var(--space-lg);
   align-items: center;
-  padding: 0 var(--space-lg);
+  padding: 0 14px;
   height: var(--navbar-height);
-  background: var(--chrome-bg);
+  background: linear-gradient(
+    180deg,
+    var(--chrome-bg) 0%,
+    var(--chrome-bg2) 100%
+  );
   border-bottom: 1px solid var(--chrome-border);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
 }
 
-.browser-toolbar__address,
 .address-form,
-.browser-toolbar__actions,
-.panel-tabs,
 .panel__row,
 .settings-actions {
   display: flex;
@@ -179,8 +187,22 @@ button.danger:hover {
   gap: var(--space-sm);
 }
 
+.browser-toolbar__center {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.browser-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
 .address-form {
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 760px;
 }
 
 .address-form.is-disabled {
@@ -192,6 +214,7 @@ button.danger:hover {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
+  min-width: 0;
 }
 
 .toolbar-brand__text {
@@ -204,37 +227,53 @@ button.danger:hover {
 
 .toolbar-brand__logo {
   display: block;
-  height: 24px;
+  height: 26px;
   width: auto;
 }
 
 .address-form__input {
-  flex: 1;
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--chrome-border);
+  border-radius: 10px;
+  background: var(--chrome-input);
+  transition: background 0.15s;
+}
+
+.address-form__input:focus-within {
+  background: rgba(255, 255, 255, 0.3);
 }
 
 .address-form__input input {
-  width: 100%;
-  padding: 7px 12px;
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.2);
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: var(--chrome-text);
-  font-size: 13px;
+  font:
+    13px ui-monospace,
+    "SFMono-Regular",
+    monospace;
+  outline: none;
 }
 
 .address-form__input input::placeholder {
   color: var(--chrome-text-muted);
 }
 
-.address-form__input input:focus {
-  background: rgba(255, 255, 255, 0.3);
-  border-color: rgba(255, 255, 255, 0.5);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.15);
-  outline: none;
+.toolbar-separator {
+  width: 1px;
+  height: 20px;
+  background: var(--chrome-border);
+  margin: 0 6px;
 }
 
 .address-form__input input:disabled,
-.toolbar-link:disabled,
 .settings-field select:disabled,
 .settings-actions button:disabled {
   cursor: not-allowed;
@@ -242,10 +281,20 @@ button.danger:hover {
 }
 
 /* Toolbar icon buttons (on maroon background) */
+.nav-buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+  padding: 2px;
+  background: var(--chrome-cluster);
+  border-radius: 10px;
+}
+
 .browser-toolbar .icon-button {
-  width: 36px;
-  min-width: 36px;
-  height: 36px;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
   padding: 0;
   display: inline-flex;
   align-items: center;
@@ -254,13 +303,14 @@ button.danger:hover {
   border-color: transparent;
   border-radius: var(--radius-md);
   color: var(--chrome-text-muted);
-  font-size: 16px;
+  font-size: 15px;
 }
 
 .browser-toolbar .icon-button--labeled {
   width: auto;
   padding: 0 12px;
-  gap: var(--space-xs);
+  gap: 6px;
+  text-decoration: none;
 }
 
 .browser-toolbar .icon-button__label {
@@ -274,6 +324,18 @@ button.danger:hover {
   background: var(--chrome-hover);
   color: var(--chrome-text);
   border-color: transparent;
+}
+
+.browser-toolbar .icon-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: transparent;
+  color: var(--chrome-text-muted);
+}
+
+.browser-toolbar .icon-button[aria-expanded="true"] {
+  background: var(--chrome-hover);
+  color: var(--chrome-text);
 }
 
 /* Generic icon button (for non-toolbar contexts) */
@@ -295,20 +357,6 @@ button.danger:hover {
 .icon-button:hover {
   background: var(--color-gray-100);
   color: var(--text);
-  border-color: transparent;
-}
-
-.toolbar-link {
-  background: transparent;
-  border-color: transparent;
-  color: var(--chrome-text-muted);
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.toolbar-link:hover {
-  color: var(--chrome-text);
-  background: var(--chrome-hover);
   border-color: transparent;
 }
 
@@ -350,8 +398,9 @@ button.danger:hover {
 .side-panel {
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr) auto;
-  border-left: 1px solid var(--chrome-border);
+  border-left: 1px solid var(--border);
   background: var(--bg-surface);
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.04);
   min-height: 0;
   overflow: hidden;
 }
@@ -360,26 +409,45 @@ button.danger:hover {
   display: none;
 }
 
-.side-panel__header,
-.side-panel__content,
-.side-panel__footer {
-  padding: var(--space-lg);
-}
-
-.panel-tabs {
-  padding: var(--space-sm) var(--space-lg);
-}
-
 .side-panel__header {
-  background: var(--chrome-bg);
-  border-bottom: 1px solid var(--chrome-border);
-  padding: var(--space-md) var(--space-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 12px var(--space-lg) 10px;
 }
 
-.side-panel__header strong {
-  display: block;
-  color: var(--chrome-text);
+.side-panel__title {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.side-panel__title strong {
+  font-size: 13.5px;
+  color: var(--text-heading);
+}
+
+.side-panel__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
   font-size: 14px;
+  cursor: pointer;
+}
+
+.side-panel__close:hover {
+  background: var(--color-gray-100);
+  color: var(--text);
+  border-color: transparent;
 }
 
 .remote-boot__card strong {
@@ -388,44 +456,49 @@ button.danger:hover {
   font-size: 14px;
 }
 
-.side-panel__header span {
-  color: var(--chrome-text-muted);
-  font-size: 12px;
-}
-
-/* -- Panel tabs -------------------------------------------- */
+/* -- Panel tabs (segmented control) ------------------------ */
 .panel-tabs {
-  gap: 4px;
-  background: var(--chrome-bg);
-  border-bottom: 1px solid var(--chrome-border);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin: 0 var(--space-lg) var(--space-md);
+  padding: 3px;
+  background: var(--color-gray-100);
+  border-radius: 9px;
 }
 
 .panel-tab {
+  flex: 1;
+  padding: 5px 0;
+  border: 0;
+  border-radius: 7px;
   background: transparent;
-  border-color: transparent;
-  color: var(--chrome-text-muted);
-  font-size: 13px;
-  padding: 6px 12px;
-  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
 .panel-tab:hover {
-  color: var(--chrome-text);
-  background: var(--chrome-hover);
+  color: var(--text);
+  background: transparent;
   border-color: transparent;
 }
 
 .panel-tab.is-active {
-  background: var(--chrome-active);
-  border-color: var(--chrome-border);
-  color: var(--chrome-text);
+  background: var(--color-white);
+  color: var(--text-heading);
   font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
 /* -- Panel content ----------------------------------------- */
 .side-panel__content {
   overflow: auto;
   min-height: 0;
+  padding: var(--space-xs) var(--space-lg) var(--space-lg);
 }
 
 .side-panel__content.is-hidden {
@@ -441,39 +514,52 @@ button.danger:hover {
 
 /* -- Panel footer ------------------------------------------ */
 .side-panel__footer {
-  display: grid;
-  gap: var(--space-sm);
-  border-top: 1px solid var(--chrome-border);
-  background: var(--chrome-bg);
-  color: var(--chrome-text-muted);
-  font-size: 12px;
-  padding: var(--space-md) var(--space-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-top: 1px solid var(--border-light);
+  background: var(--bg-surface-muted);
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 10px var(--space-lg);
+}
+
+.side-panel__footer-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
 
 .side-panel__footer p {
   margin: 0;
 }
 
-.side-panel__footer a {
-  color: var(--chrome-text);
+.side-panel__footer-text a {
+  color: var(--accent-hover);
+  font-weight: 600;
   text-decoration: none;
 }
 
-.side-panel__footer a:hover {
-  color: var(--color-white);
+.side-panel__footer-text a:hover {
+  color: var(--accent);
 }
 
 .side-panel__footer-link {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-sm);
-  width: fit-content;
-  font-weight: 600;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.side-panel__footer-link:hover {
+  color: var(--text);
 }
 
 .side-panel__footer-link svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 /* -- Settings fields (sidebar) ----------------------------- */
@@ -528,13 +614,18 @@ button.danger:hover {
   flex-wrap: wrap;
   row-gap: var(--space-xs);
   margin-bottom: var(--space-sm);
+  color: var(--text-muted);
+}
+
+/* Uppercase mono section label (the row's leading span only, so buttons
+   in the same row keep the regular UI font). */
+.panel__row > span:first-child:not(.panel__row-actions) {
   font:
     600 11px / 1.2 ui-monospace,
     "SFMono-Regular",
     monospace;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--text-muted);
 }
 
 .panel__row-actions {
@@ -689,12 +780,24 @@ button.danger:hover {
 
 /* ── Config / Info building blocks (sidebar redesign) ── */
 .info-stack {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: var(--space-xl);
+  min-height: 100%;
 }
 .info-section {
   display: grid;
   gap: var(--space-md);
+}
+.info-section--bottom {
+  margin-top: auto;
+  gap: var(--space-sm);
+}
+
+.config-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
 }
 
 .section-label {
@@ -826,13 +929,6 @@ button.danger:hover {
   background: var(--color-gray-100);
 }
 
-.divider {
-  height: 1px;
-  background: var(--border-light);
-  border: 0;
-  margin: 0;
-}
-
 .muted-help {
   font-size: 12px;
   color: var(--text-muted);
@@ -877,7 +973,6 @@ button.danger:hover {
 
 @media (max-width: 720px) {
   .browser-toolbar {
-    grid-template-columns: minmax(0, 1fr) auto;
     padding: 0 var(--space-md);
     gap: var(--space-sm);
   }
@@ -886,18 +981,27 @@ button.danger:hover {
     display: none;
   }
 
-  #home-button,
+  .toolbar-separator,
   #admin-button {
     display: none;
   }
 
-  #refresh-button {
-    display: none;
+  /* The brand is a wide wordmark: let it scale down instead of pushing the
+     nav cluster underneath the toolbar actions on narrow screens. */
+  .toolbar-brand {
+    overflow: hidden;
+  }
+
+  .toolbar-brand__logo {
+    height: 22px;
+    max-width: 100%;
+    object-fit: contain;
+    object-position: left center;
   }
 
   .browser-toolbar .icon-button--labeled {
-    width: 36px;
-    min-width: 36px;
+    width: 32px;
+    min-width: 32px;
     padding: 0;
   }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -258,6 +258,11 @@ button.danger:hover {
 
 .address-form__input input {
   flex: 1;
+  /* An input contributes its intrinsic ~20-character width to intrinsic
+     sizing, which would become a hard floor for the toolbar's centre column
+     and overflow the bar on narrow phones. `width: 0` drops that floor; the
+     input still fills the pill through flex-grow. */
+  width: 0;
   min-width: 0;
   padding: 0;
   border: 0;
@@ -990,7 +995,9 @@ button.danger:hover {
     gap: var(--space-sm);
   }
 
-  /* Minimal mobile toolbar: app icon, Home, Admin, and the panel toggle. */
+  /* Minimal mobile toolbar: app icon, Home, Admin, a narrow URL bar and the
+     panel toggle. The URL bar is the flexible element — it keeps whatever
+     width the fixed controls leave. */
   .toolbar-brand__logo {
     display: none;
   }
@@ -999,7 +1006,6 @@ button.danger:hover {
     display: block;
   }
 
-  .address-form__input,
   .toolbar-separator,
   .browser-toolbar .icon-button--labeled,
   .browser-toolbar .toolbar-github,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -231,6 +231,14 @@ button.danger:hover {
   width: auto;
 }
 
+/* Compact app icon: swapped in for the wordmark on the mobile toolbar. */
+.toolbar-brand__icon {
+  display: none;
+  height: 26px;
+  width: 26px;
+  border-radius: 6px;
+}
+
 .address-form__input {
   display: flex;
   align-items: center;
@@ -982,34 +990,21 @@ button.danger:hover {
     gap: var(--space-sm);
   }
 
-  .address-form__input {
-    display: none;
-  }
-
-  .toolbar-separator {
-    display: none;
-  }
-
-  /* The brand is a wide wordmark: let it scale down instead of pushing the
-     nav cluster underneath the toolbar actions on narrow screens. */
-  .toolbar-brand {
-    overflow: hidden;
-  }
-
+  /* Minimal mobile toolbar: app icon, Home, Admin, and the panel toggle. */
   .toolbar-brand__logo {
-    height: 22px;
-    max-width: 100%;
-    object-fit: contain;
-    object-position: left center;
+    display: none;
   }
 
-  .browser-toolbar .icon-button--labeled {
-    width: 32px;
-    min-width: 32px;
-    padding: 0;
+  .toolbar-brand__icon {
+    display: block;
   }
 
-  .browser-toolbar .icon-button__label {
+  .address-form__input,
+  .toolbar-separator,
+  .browser-toolbar .icon-button--labeled,
+  .browser-toolbar .toolbar-github,
+  #back-button,
+  #refresh-button {
     display: none;
   }
 

--- a/src/styles/blueprint-editor.css
+++ b/src/styles/blueprint-editor.css
@@ -86,7 +86,8 @@
   color: var(--text-muted);
 }
 
-/* ── Toolbar buttons: Run/Export/Import/Copy, all in the top row ──────
+/* ── Panel row buttons: Run/Export/Import/Copy plus the Logs and PHP Info
+   row actions ────────────────────────────────────────────────────────
    Named .bp-btn (not .icon-button) — this repo already has a global,
    fixed-36px .icon-button class used elsewhere, incompatible with the
    wide/labeled/primary variants needed here. */
@@ -105,20 +106,48 @@
 
 .bp-btn--icon-only {
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   padding: 0;
 }
 
+/* Quiet, borderless icon actions (design: Shell UI v2) — the higher
+   specificity also neutralises the base `label.import-button` border. */
+.panel__row-actions .bp-btn--icon-only {
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.panel__row-actions .bp-btn--icon-only:hover {
+  background: var(--color-gray-100);
+  color: var(--text);
+}
+
+.panel__row-actions .bp-btn--icon-only:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: transparent;
+  color: var(--text-muted);
+}
+
 .bp-btn--wide {
-  min-width: 76px;
   justify-content: center;
+  width: auto;
+  min-width: 0;
+  height: auto;
 }
 
 .bp-btn--primary {
   color: var(--color-white);
   background: var(--accent);
   border-color: transparent;
+  border-radius: 7px;
+  padding: 5px 14px;
+  font-size: 12.5px;
+  font-weight: 600;
+  gap: 6px;
 }
 
 .bp-btn--primary:hover {


### PR DESCRIPTION
Applies the **Shell UI v2** design to the playground chrome, mirroring
ateeducacion/moodle-playground#284 while keeping Omeka S Playground's own
maroon brand, logo, texts and links.

## Toolbar

- Three-zone CSS grid: brand logo | centered nav cluster + URL bar (max 760px) | actions, 54px tall
- Vertical maroon gradient (`#ab364b` → `--color-maroon-soft`), 1px border and a softer shadow
- Back / Refresh / Home / Admin grouped in a rounded nav cluster; **Back is new** and is backed by an
  in-shell navigation history stack (the nested iframe/service-worker scopes make the browser's own
  session history unusable here)
- URL bar is a 34px pill with a monospace input and a `:focus-within` highlight
- Actions: Docs, a new GitHub link, a separator, and the panel toggle, which now shows an
  active state via `[aria-expanded="true"]`
- The centre column keeps a `min-content` floor so the wide Omeka wordmark scales down on narrow
  viewports instead of pushing the nav cluster underneath the actions

## Side panel

- White surface with a left border and a soft shadow
- Header is now "Runtime" + the live status pill + a close (✕) button that collapses the panel
  through the same toggle path (so `aria-expanded` stays in sync)
- Tabs became a segmented control; "PHP Info" is shortened to "PHP" (ids unchanged)
- Info tab: Omeka and PHP selects side by side, the `<hr class="divider">` is gone, and the Reset
  section is pinned to the bottom of the panel
- Danger buttons are now outline-style and fill red on hover
- Footer is a light surface with 11px text and an icon-only GitHub link
- Logs / PHP Info / Blueprint rows use quiet icon-only actions; in the Blueprint row the Run button
  moved out of the actions group to the left
- Blueprint status now reads `✓ Valid blueprint` (no step count — blueprints here are declarative
  sections, not an ordered step list)

All existing element ids, ARIA attributes and state classes are preserved
(`#address-input`, `#home-button`, `#admin-button`, `#panel-toggle-button` + `aria-expanded`,
`#side-panel` + `is-collapsed`, tab ids, …). The now-unused `.toolbar-link` and `.divider` rules
were removed.

## Tests

- `make lint` — passes (exit 0; the 4 pre-existing warnings are in untouched files)
- `make test` — 177/177 pass
- `npx playwright test tests/e2e/shell.spec.mjs` — 6/6 pass (run against a local dev server on
  port 8153 via `PLAYWRIGHT_EXTERNAL_SERVER=1`)
- `node --check` on `src/shell/main.js` and `src/shell/blueprint-editor-core.js`
- Manual browser pass in headless Chromium with a fresh profile: full boot to the Omeka admin
  dashboard, panel open on every tab, toolbar measured at 360/390/720/1024/1440px (no overlap,
  no horizontal overflow). Back button verified end to end (disabled → navigate to `/admin/item`
  → enabled → Back returns to `/admin` and disables again) and the panel close button verified to
  collapse the panel and reset `aria-expanded` to `false`.


## Follow-ups

- **Minimal mobile toolbar.** Below 720px the brand wordmark is swapped for the square app icon
  (the site `favicon.ico` at 26x26 with a 6px radius) and everything duplicated by Omeka's own
  chrome or unusable at that width is hidden: Back, Refresh, Docs, the GitHub link and the
  separator. What remains is app icon + Home + Admin + a narrow URL bar + panel toggle, with the
  URL bar taking whatever width the fixed controls leave.
  Keeping the URL bar exposed a sizing problem worth calling out: an `<input>` contributes its
  intrinsic ~20-character width to intrinsic sizing, so the centre grid column
  (`minmax(min-content, 1fr)`) inherited a ~190px floor and the toolbar overflowed — clipped rather
  than scrollable, since the body hides overflow — pushing the app icon off the left edge and the
  panel toggle past the right below ~370px. `width: 0` on the input drops that floor while
  flex-grow still fills the pill.
  Verified at 1440/720/414/390/375/360/320px: the brand always sits at 12px from the left, the
  toggle always ends 12px from the right, and the URL bar shrinks from 614px down to 144px. Typing
  a path into the narrow bar at 390px navigates the site frame, Home and Admin still go to
  `/s/playground` and `/admin`, and the full-screen panel still opens and closes.
- **Admin moved into the nav cluster.** Home and Admin now sit together (Back / Refresh / Home /
  Admin), the way WordPress Playground pairs home and dashboard, instead of Admin living in the
  right-hand actions zone. It is an icon-only 32x32 button like the rest of the cluster (id
  `#admin-button` and its behavior unchanged; `title="Admin"`, `aria-label="Go to admin panel"`) and
  it is no longer hidden below 720px. Verified at 1440/1024/720/390/360px: the four buttons stay on
  one row, the cluster never overlaps the actions zone (8px clear at 390px) and the page never
  scrolls horizontally — the `minmax(min-content, 1fr)` centre column still holds with the extra
  button. Clicking Home then Admin navigates to `/s/playground` and `/admin`.
- **Full-screen panel on narrow viewports.** Below 1080px the open panel now covers the whole area
  under the toolbar (`position: fixed`, `z-index: 15`, below the toolbar's 20) instead of splitting
  the screen with the site; the old `grid-template-rows: 1fr 1fr` split is gone. `is-collapsed`
  still hides it, so the flow is open → configure → dismiss with the ✕ or the toolbar toggle.
  Measured at 390px: panel `0,54 → 390×706` (viewport 390×760, toolbar 54px); at 1000px:
  `0,54 → 1000×746`; at 1440px the sidebar is unchanged (static, 340px).
- **Back now records in-site navigations.** The remote frame emits `ready` before `navigate` on
  every iframe load (omeka's equivalent of moodle's `frame-ready`), and the `ready` handler had
  already advanced `currentPath`, so by the time `navigate` arrived the two paths were equal and
  nothing was ever pushed — Back only worked for toolbar-driven navigation. The transition is now
  recorded in the `ready` handler, skipping the first load after boot/restore so the landing
  redirect does not leave Back enabled. Verified end to end: after boot Back is disabled; clicking
  *Items* then *Item sets* inside the Omeka admin enables it; Back twice walks
  `/admin/item-set → /admin/item → /admin` and ends disabled again.

**Mobile (390×760) — panel open, full screen**

![omeka-pr-mobile.png](https://github.com/user-attachments/assets/8615106b-9b79-45f1-abfe-0c1a58e7bad3)

## Screenshots

**Desktop (1440×900) — Info tab**

![omeka-desktop-info.png](https://github.com/user-attachments/assets/0e6c31d6-ad03-4618-9152-0c5ff45a59a6)

**Desktop — Blueprint tab (Run moved left, quiet icon actions)**

![omeka-desktop-blueprint.png](https://github.com/user-attachments/assets/25191e6c-4f73-4209-bff0-3e0109036ce8)

**Mobile (390×760) — minimal toolbar**

![omeka-mobile-toolbar.png](https://github.com/user-attachments/assets/10d97c24-c751-4600-a667-9f6c71b0ec3a)




