### PR TITLE
Add Sentry error monitoring via a minimal envelope client

### DIFF
--- a/docs/architecture/adr/ADR-0028-sentry-error-monitoring.md
+++ b/docs/architecture/adr/ADR-0028-sentry-error-monitoring.md
@@ -1,0 +1,54 @@
+---
+id: ADR-0028
+title: "Sentry error monitoring via a minimal hand-rolled envelope client"
+status: Proposed
+date: 2026-08-15
+---
+
+# ADR-0028: Sentry error monitoring via a minimal hand-rolled envelope client
+
+## Context
+
+Deployed playground sessions fail silently: the only trace of a broken session
+is the in-page Logs panel, which the affected visitor rarely reports. There is
+no server, so there are no server logs. A Sentry organization (`erseco`)
+already hosts monitoring for sibling projects; the new project is
+`omeka-s-playground` (EU/DE data region).
+
+The shell (`src/shell/main.js`) is served as an unbundled ES module straight
+from source, so an npm SDK cannot be bundled for it, and the app is otherwise
+self-contained (no third-party CDN requests). The worker already funnels every
+serious runtime failure to the shell as `kind: "error"` BroadcastChannel
+messages, making the shell a natural single capture point for the whole stack.
+
+## Decision
+
+1. Implement a minimal Sentry client at `src/shared/monitoring.js` (~250
+   lines, zero dependencies) that posts envelope payloads directly to the
+   DSN's `/api/<id>/envelope/` ingest endpoint via
+   `fetch(..., { keepalive: true })`, instead of `@sentry/browser` (~80 KB,
+   needs bundling) or the CDN Loader Script (third-party request, blocked by
+   ad blockers).
+2. Enable it from the shell when `playground.config.json` provides
+   `sentry.dsn`; without it the client is a no-op. Committed browser DSNs are
+   public identifiers by design (they only authorize event submission).
+3. Capture: uncaught `window` errors, `unhandledrejection`, `main()` boot
+   failures, and every `kind: "error"` message relayed from the runtime
+   worker. Tag events with `runtime`, `omekaVersion`, `phpVersion`, and use
+   `BUILD_VERSION` as the release. Environment is auto-detected
+   (`development` on localhost, `production` otherwise), overridable via
+   `sentry.environment`.
+4. Safety rails: hard 30-event session cap, per-session dedupe by event
+   signature, fire-and-forget delivery, and capture paths that never throw
+   into the app.
+
+## Consequences
+
+- Production failures become visible with version, runtime, and browser
+  context attached; deployments without a DSN are unaffected.
+- No breadcrumbs, session replay, or performance tracing; revisit toward the
+  official SDK if those are ever needed.
+- The envelope format (`sentry_version=7`, stable) is maintained by hand,
+  pinned by unit tests in `tests/shared-monitoring.test.mjs`.
+- Ad blockers commonly block Sentry ingest hosts; monitoring is best-effort
+  telemetry, not an audit log.

--- a/docs/architecture/adr/records.md
+++ b/docs/architecture/adr/records.md
@@ -3,3 +3,4 @@
 | ADR | Title | Status | Date |
 | --- | --- | --- | --- |
 | [ADR-0027](ADR-0027-selective-crash-recovery-snapshots.md) | Coherent selective crash recovery checkpoints | Proposed | 2026-07-12 |
+| [ADR-0028](ADR-0028-sentry-error-monitoring.md) | Sentry error monitoring via a minimal hand-rolled envelope client | Proposed | 2026-08-15 |

--- a/playground.config.json
+++ b/playground.config.json
@@ -4,6 +4,9 @@
   "addonProxyPath": "/__addon_proxy__",
   "addonProxyUrl": "https://zip-proxy.erseco.workers.dev/",
   "phpCorsProxyUrl": "https://zip-proxy.erseco.workers.dev/?url=",
+  "sentry": {
+    "dsn": "https://7481b585a56a736587724327eee09387@o4510456164712448.ingest.de.sentry.io/4511915921834064"
+  },
   "siteTitle": "Omeka S Playground",
   "landingPath": "/admin",
   "locale": "en_US",

--- a/src/shared/monitoring.js
+++ b/src/shared/monitoring.js
@@ -1,0 +1,298 @@
+// Minimal Sentry error-monitoring client (no SDK dependency).
+// See docs/architecture/adr/ADR-0028-sentry-error-monitoring.md
+//
+// The shell loads as an unbundled ES module straight from source, so this
+// client is hand-rolled instead of pulling in @sentry/browser: it posts plain
+// envelope payloads to Sentry's ingest endpoint with fetch() and degrades to
+// a no-op whenever no DSN is configured or delivery fails.
+
+const CLIENT_NAME = "omeka-s-playground-monitoring";
+const CLIENT_VERSION = "1.0.0";
+const MAX_EVENTS_PER_SESSION = 30;
+const MAX_STACK_FRAMES = 50;
+
+/**
+ * Parse a Sentry DSN (https://<publicKey>@<host>/<path?>/<projectId>) into
+ * the pieces needed to build the envelope ingest URL. Returns null when the
+ * DSN is missing or malformed — callers treat that as "monitoring disabled".
+ */
+export function parseDsn(dsn) {
+  if (!dsn || typeof dsn !== "string") {
+    return null;
+  }
+
+  let url;
+  try {
+    url = new URL(dsn);
+  } catch {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const projectId = segments.pop();
+  if (!url.username || !projectId || !/^\d+$/.test(projectId)) {
+    return null;
+  }
+
+  const basePath = segments.length ? `/${segments.join("/")}` : "";
+  return {
+    publicKey: url.username,
+    host: url.host,
+    projectId,
+    envelopeUrl:
+      `${url.protocol}//${url.host}${basePath}/api/${projectId}/envelope/` +
+      `?sentry_key=${url.username}&sentry_version=7` +
+      `&sentry_client=${CLIENT_NAME}%2F${CLIENT_VERSION}`,
+  };
+}
+
+/**
+ * Best-effort parser for V8 ("at fn (url:line:col)") and Firefox/Safari
+ * ("fn@url:line:col") stack strings. Sentry expects frames ordered from
+ * oldest call to newest, so the parsed list is reversed.
+ */
+export function parseStackFrames(stack) {
+  if (!stack || typeof stack !== "string") {
+    return [];
+  }
+
+  const frames = [];
+  for (const line of stack.split("\n")) {
+    const text = line.trim();
+    const v8 = text.match(/^at\s+(?:(.*?)\s+\()?(.*?):(\d+):(\d+)\)?$/);
+    const gecko = text.match(/^(?:(.*?)@)?(.+?):(\d+):(\d+)$/);
+    const match = v8 || gecko;
+    if (!match || match[2].startsWith("<")) {
+      continue;
+    }
+    frames.push({
+      function: match[1] || "?",
+      filename: match[2],
+      lineno: Number(match[3]),
+      colno: Number(match[4]),
+      in_app: true,
+    });
+    if (frames.length >= MAX_STACK_FRAMES) {
+      break;
+    }
+  }
+
+  return frames.reverse();
+}
+
+function generateEventId() {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID().replaceAll("-", "");
+  }
+  let id = "";
+  while (id.length < 32) {
+    id += Math.floor(Math.random() * 16).toString(16);
+  }
+  return id;
+}
+
+function detectEnvironment() {
+  const hostname = globalThis.location?.hostname || "";
+  if (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname.endsWith(".local")
+  ) {
+    return "development";
+  }
+  return "production";
+}
+
+/**
+ * Build a Sentry event payload. Pass either an Error-like `error` or a plain
+ * string `message`. Exported for tests.
+ */
+export function buildEvent({
+  error,
+  message,
+  level = "error",
+  release,
+  environment,
+  tags,
+  extra,
+}) {
+  const event = {
+    event_id: generateEventId(),
+    timestamp: Date.now() / 1000,
+    platform: "javascript",
+    logger: "omeka-s-playground",
+    level,
+    sdk: { name: CLIENT_NAME, version: CLIENT_VERSION },
+  };
+
+  if (release) {
+    event.release = release;
+  }
+  event.environment = environment || detectEnvironment();
+  if (tags && Object.keys(tags).length) {
+    event.tags = tags;
+  }
+  if (extra && Object.keys(extra).length) {
+    event.extra = extra;
+  }
+
+  const pageUrl = globalThis.location?.href;
+  if (pageUrl) {
+    event.request = { url: pageUrl };
+    const userAgent = globalThis.navigator?.userAgent;
+    if (userAgent) {
+      event.request.headers = { "User-Agent": userAgent };
+    }
+  }
+
+  if (error) {
+    const value = {
+      type: error.name || "Error",
+      value: String(error.message ?? error),
+      mechanism: { type: "generic", handled: true },
+    };
+    const frames = parseStackFrames(error.stack);
+    if (frames.length) {
+      value.stacktrace = { frames };
+    }
+    event.exception = { values: [value] };
+  } else {
+    event.message = { formatted: String(message) };
+  }
+
+  return event;
+}
+
+/** Serialize an event into a Sentry envelope body. Exported for tests. */
+export function buildEnvelope(event, dsn) {
+  const header = {
+    event_id: event.event_id,
+    sent_at: new Date().toISOString(),
+    sdk: { name: CLIENT_NAME, version: CLIENT_VERSION },
+  };
+  if (dsn) {
+    header.dsn = dsn;
+  }
+  return `${JSON.stringify(header)}\n${JSON.stringify({ type: "event" })}\n${JSON.stringify(event)}\n`;
+}
+
+function eventSignature(event) {
+  const exception = event.exception?.values?.[0];
+  const detail = exception
+    ? `${exception.type}:${exception.value}`
+    : event.message?.formatted || "";
+  return `${event.level}:${detail}`;
+}
+
+/**
+ * Create a monitoring client. Returns a disabled no-op client when the DSN is
+ * missing or invalid, so callers never need to branch. Capture calls must
+ * never throw — monitoring failures cannot be allowed to break the shell.
+ */
+export function createMonitoringClient(options = {}) {
+  const {
+    dsn,
+    release,
+    environment,
+    tags,
+    fetchImpl = globalThis.fetch?.bind(globalThis),
+    maxEvents = MAX_EVENTS_PER_SESSION,
+  } = options;
+
+  const target = parseDsn(dsn);
+  if (!target || typeof fetchImpl !== "function") {
+    return {
+      enabled: false,
+      captureException() {},
+      captureMessage() {},
+    };
+  }
+
+  const seenSignatures = new Set();
+  let sentCount = 0;
+
+  function send(event) {
+    const signature = eventSignature(event);
+    if (sentCount >= maxEvents || seenSignatures.has(signature)) {
+      return;
+    }
+    seenSignatures.add(signature);
+    sentCount += 1;
+
+    try {
+      const result = fetchImpl(target.envelopeUrl, {
+        method: "POST",
+        body: buildEnvelope(event, dsn),
+        // keepalive lets crash reports survive page unloads.
+        keepalive: true,
+      });
+      // Delivery is fire-and-forget; a failed report must stay invisible.
+      result?.catch?.(() => {});
+    } catch {
+      // Ignore — see above.
+    }
+  }
+
+  return {
+    enabled: true,
+    captureException(error, extra) {
+      try {
+        const normalized =
+          error instanceof Error ? error : new Error(String(error));
+        send(
+          buildEvent({ error: normalized, release, environment, tags, extra }),
+        );
+      } catch {
+        // Never let monitoring break the caller.
+      }
+    },
+    captureMessage(message, level = "info", extra) {
+      try {
+        send(buildEvent({ message, level, release, environment, tags, extra }));
+      } catch {
+        // Never let monitoring break the caller.
+      }
+    },
+  };
+}
+
+let activeClient = null;
+
+/**
+ * Initialize the module-level client and hook uncaught errors / unhandled
+ * promise rejections in window contexts. Safe to call with no DSN — the
+ * exported capture helpers become no-ops.
+ */
+export function initMonitoring(options = {}) {
+  activeClient = createMonitoringClient(options);
+
+  const scope = options.scope || globalThis;
+  if (activeClient.enabled && typeof scope.addEventListener === "function") {
+    scope.addEventListener("error", (event) => {
+      if (event?.error) {
+        activeClient.captureException(event.error, {
+          source: "window.onerror",
+        });
+      } else if (event?.message) {
+        activeClient.captureMessage(event.message, "error", {
+          source: "window.onerror",
+        });
+      }
+    });
+    scope.addEventListener("unhandledrejection", (event) => {
+      activeClient.captureException(event?.reason ?? "Unhandled rejection", {
+        source: "unhandledrejection",
+      });
+    });
+  }
+
+  return activeClient;
+}
+
+export function captureException(error, extra) {
+  activeClient?.captureException(error, extra);
+}
+
+export function captureMessage(message, level = "info", extra) {
+  activeClient?.captureMessage(message, level, extra);
+}

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -9,6 +9,11 @@ import {
 } from "../shared/blueprint.js";
 import { loadPlaygroundConfig } from "../shared/config.js";
 import {
+  captureException,
+  captureMessage,
+  initMonitoring,
+} from "../shared/monitoring.js";
+import {
   DEFAULT_OMEKA_VERSION,
   DEFAULT_PHP_VERSION,
   getCompatiblePhpVersions,
@@ -429,6 +434,7 @@ function bindShellChannel() {
         remoteFrameBooted = false;
         setUiLocked(false);
         appendLog(message.detail, true);
+        captureMessage(message.detail, "error", { source: "runtime" });
         if (!latestPhpInfoHtml) {
           capturePhpInfoViaWorker("bootstrap-error");
         }
@@ -604,6 +610,19 @@ async function main() {
   appendLog(
     `Runtime selection: php=${currentPhpVersion}, omeka=${currentOmekaVersion}, runtime=${currentRuntimeId}`,
   );
+
+  // Error monitoring (Sentry) — a no-op unless config.sentry.dsn is set.
+  // See docs/architecture/adr/ADR-0028-sentry-error-monitoring.md
+  initMonitoring({
+    dsn: config.sentry?.dsn,
+    environment: config.sentry?.environment,
+    release: BUILD_VERSION,
+    tags: {
+      runtime: currentRuntimeId,
+      omekaVersion: currentOmekaVersion,
+      phpVersion: currentPhpVersion,
+    },
+  });
   currentPath = shouldForceCleanBoot
     ? preferredPath
     : shouldBypassSavedLogin
@@ -751,4 +770,5 @@ els.reset.addEventListener("click", () => {
 main().catch((error) => {
   setUiLocked(false);
   appendLog(String(error?.stack || error?.message || error), true);
+  captureException(error, { source: "shell-main" });
 });

--- a/tests/shared-monitoring.test.mjs
+++ b/tests/shared-monitoring.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildEnvelope,
+  buildEvent,
+  createMonitoringClient,
+  initMonitoring,
+  parseDsn,
+  parseStackFrames,
+} from "../src/shared/monitoring.js";
+
+const TEST_DSN = "https://abc123@o111.ingest.de.sentry.io/222";
+
+describe("parseDsn", () => {
+  it("parses a hosted sentry.io DSN", () => {
+    const parsed = parseDsn(TEST_DSN);
+    assert.strictEqual(parsed.publicKey, "abc123");
+    assert.strictEqual(parsed.host, "o111.ingest.de.sentry.io");
+    assert.strictEqual(parsed.projectId, "222");
+    assert.ok(
+      parsed.envelopeUrl.startsWith(
+        "https://o111.ingest.de.sentry.io/api/222/envelope/?sentry_key=abc123",
+      ),
+    );
+  });
+
+  it("preserves a self-hosted path prefix", () => {
+    const parsed = parseDsn("https://key@sentry.example.com/prefix/42");
+    assert.strictEqual(parsed.projectId, "42");
+    assert.ok(
+      parsed.envelopeUrl.startsWith(
+        "https://sentry.example.com/prefix/api/42/envelope/",
+      ),
+    );
+  });
+
+  it("returns null for missing or malformed DSNs", () => {
+    assert.strictEqual(parseDsn(undefined), null);
+    assert.strictEqual(parseDsn(""), null);
+    assert.strictEqual(parseDsn("not a url"), null);
+    assert.strictEqual(parseDsn("https://host/123"), null);
+    assert.strictEqual(parseDsn("https://key@host/not-numeric"), null);
+  });
+});
+
+describe("parseStackFrames", () => {
+  it("parses V8-style stacks and reverses frame order", () => {
+    const stack = [
+      "TypeError: boom",
+      "    at inner (https://example.com/app.js:10:5)",
+      "    at outer (https://example.com/app.js:20:15)",
+    ].join("\n");
+    const frames = parseStackFrames(stack);
+    assert.strictEqual(frames.length, 2);
+    assert.strictEqual(frames[0].function, "outer");
+    assert.strictEqual(frames[1].function, "inner");
+    assert.strictEqual(frames[1].lineno, 10);
+    assert.strictEqual(frames[1].colno, 5);
+    assert.strictEqual(frames[1].filename, "https://example.com/app.js");
+  });
+
+  it("parses Firefox/Safari-style stacks", () => {
+    const frames = parseStackFrames("fn@https://example.com/app.js:3:7");
+    assert.strictEqual(frames.length, 1);
+    assert.strictEqual(frames[0].function, "fn");
+    assert.strictEqual(frames[0].lineno, 3);
+  });
+
+  it("returns an empty list for missing stacks", () => {
+    assert.deepStrictEqual(parseStackFrames(undefined), []);
+    assert.deepStrictEqual(parseStackFrames("TypeError: boom"), []);
+  });
+});
+
+describe("buildEvent", () => {
+  it("builds an exception event from an Error", () => {
+    const error = new TypeError("boom");
+    const event = buildEvent({
+      error,
+      release: "r1",
+      environment: "test",
+      tags: { runtime: "php83" },
+    });
+    assert.match(event.event_id, /^[0-9a-f]{32}$/);
+    assert.strictEqual(event.platform, "javascript");
+    assert.strictEqual(event.level, "error");
+    assert.strictEqual(event.release, "r1");
+    assert.strictEqual(event.environment, "test");
+    assert.deepStrictEqual(event.tags, { runtime: "php83" });
+    const exception = event.exception.values[0];
+    assert.strictEqual(exception.type, "TypeError");
+    assert.strictEqual(exception.value, "boom");
+    assert.ok(exception.stacktrace.frames.length > 0);
+  });
+
+  it("builds a message event with the given level", () => {
+    const event = buildEvent({ message: "hello", level: "warning" });
+    assert.strictEqual(event.level, "warning");
+    assert.strictEqual(event.message.formatted, "hello");
+    assert.strictEqual(event.exception, undefined);
+  });
+});
+
+describe("buildEnvelope", () => {
+  it("serializes header, item header, and event", () => {
+    const event = buildEvent({ message: "hi" });
+    const lines = buildEnvelope(event, TEST_DSN).trimEnd().split("\n");
+    assert.strictEqual(lines.length, 3);
+    const header = JSON.parse(lines[0]);
+    assert.strictEqual(header.event_id, event.event_id);
+    assert.strictEqual(header.dsn, TEST_DSN);
+    assert.deepStrictEqual(JSON.parse(lines[1]), { type: "event" });
+    assert.strictEqual(JSON.parse(lines[2]).message.formatted, "hi");
+  });
+});
+
+function createCapturingFetch() {
+  const calls = [];
+  const fetchImpl = (url, options) => {
+    calls.push({ url, options });
+    return Promise.resolve({ ok: true });
+  };
+  return { calls, fetchImpl };
+}
+
+describe("createMonitoringClient", () => {
+  it("is a safe no-op without a DSN", () => {
+    const client = createMonitoringClient({});
+    assert.strictEqual(client.enabled, false);
+    client.captureException(new Error("boom"));
+    client.captureMessage("hello");
+  });
+
+  it("posts envelopes to the DSN ingest endpoint", () => {
+    const { calls, fetchImpl } = createCapturingFetch();
+    const client = createMonitoringClient({ dsn: TEST_DSN, fetchImpl });
+    assert.strictEqual(client.enabled, true);
+    client.captureException(new Error("boom"));
+    assert.strictEqual(calls.length, 1);
+    assert.ok(calls[0].url.includes("/api/222/envelope/"));
+    assert.strictEqual(calls[0].options.method, "POST");
+    assert.ok(calls[0].options.body.includes('"boom"'));
+  });
+
+  it("deduplicates identical events", () => {
+    const { calls, fetchImpl } = createCapturingFetch();
+    const client = createMonitoringClient({ dsn: TEST_DSN, fetchImpl });
+    client.captureMessage("same", "error");
+    client.captureMessage("same", "error");
+    client.captureMessage("different", "error");
+    assert.strictEqual(calls.length, 2);
+  });
+
+  it("stops after maxEvents", () => {
+    const { calls, fetchImpl } = createCapturingFetch();
+    const client = createMonitoringClient({
+      dsn: TEST_DSN,
+      fetchImpl,
+      maxEvents: 2,
+    });
+    client.captureMessage("one");
+    client.captureMessage("two");
+    client.captureMessage("three");
+    assert.strictEqual(calls.length, 2);
+  });
+
+  it("normalizes non-Error values", () => {
+    const { calls, fetchImpl } = createCapturingFetch();
+    const client = createMonitoringClient({ dsn: TEST_DSN, fetchImpl });
+    client.captureException("string failure");
+    assert.ok(calls[0].options.body.includes("string failure"));
+  });
+
+  it("swallows delivery failures", () => {
+    const client = createMonitoringClient({
+      dsn: TEST_DSN,
+      fetchImpl: () => {
+        throw new Error("network down");
+      },
+    });
+    client.captureException(new Error("boom"));
+    client.captureMessage("still fine");
+  });
+});
+
+describe("initMonitoring", () => {
+  it("hooks global error and unhandledrejection handlers", () => {
+    const { calls, fetchImpl } = createCapturingFetch();
+    const handlers = new Map();
+    const scope = {
+      addEventListener: (name, handler) => handlers.set(name, handler),
+    };
+    initMonitoring({ dsn: TEST_DSN, fetchImpl, scope });
+    assert.ok(handlers.has("error"));
+    assert.ok(handlers.has("unhandledrejection"));
+    handlers.get("error")({ error: new Error("uncaught") });
+    handlers.get("unhandledrejection")({ reason: new Error("rejected") });
+    assert.strictEqual(calls.length, 2);
+  });
+
+  it("does not install handlers when disabled", () => {
+    const handlers = new Map();
+    const scope = {
+      addEventListener: (name, handler) => handlers.set(name, handler),
+    };
+    const client = initMonitoring({ scope });
+    assert.strictEqual(client.enabled, false);
+    assert.strictEqual(handlers.size, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds production error monitoring with Sentry. Deployed playgrounds currently fail silently — the only trace of a broken session is the in-page Logs panel. This PR wires unhandled errors from the whole stack into the new `omeka-s-playground` Sentry project (org `erseco`, EU data region).

Same integration as moodle-playground PR ateeducacion/moodle-playground#286.

## Design

The shell is served as an **unbundled** ES module, so instead of bundling `@sentry/browser` (~80 KB) or loading a third-party CDN script, this adds `src/shared/monitoring.js` (~250 lines, zero dependencies): a minimal client that posts Sentry envelope payloads directly to the DSN ingest endpoint with `fetch(..., { keepalive: true })`.

**Captured signals** (all from the shell, the natural funnel for the whole stack):
- Uncaught `window` errors and `unhandledrejection`
- `main()` boot failures
- Every `kind: "error"` BroadcastChannel message relayed from the PHP worker

**Event context:** `runtime`, `omekaVersion`, `phpVersion` tags; `BUILD_VERSION` as the release; environment auto-detected (`development` on localhost, `production` otherwise, overridable via `sentry.environment`).

**Safety rails:** hard 30-event session cap, per-session dedupe by event signature, fire-and-forget delivery, and every capture path wrapped so monitoring can never throw into the app. Deployments without `config.sentry.dsn` get a no-op client.

The DSN committed in `playground.config.json` is a public browser key by design — it only authorizes event submission.

## ADR

- Creates **ADR-0028** (Sentry error monitoring via a minimal hand-rolled envelope client) and registers it in `docs/architecture/adr/records.md`.

## Verification

- `npm test`: 194 tests pass (17 new in `tests/shared-monitoring.test.mjs` covering DSN parsing, stack-frame parsing, envelope shape, dedupe/cap, and no-op behavior)
- `make lint`: clean
- The identical client was verified end-to-end in moodle-playground: envelope POSTs returned HTTP 200 and events appeared in the Sentry project feed.