### PR TITLE
fix: harden runtime against Sentry-reported crashes

### DIFF
--- a/lib/omeka-loader.js
+++ b/lib/omeka-loader.js
@@ -10,11 +10,28 @@ const DEFAULT_MANIFEST_URL = resolveProjectUrl(
   `assets/manifests/${buildManifestFilename(DEFAULT_OMEKA_VERSION)}`,
 ).toString();
 
+// WebKit and Firefox surface network-level fetch failures as a bare
+// "Load failed" / "NetworkError when attempting to fetch resource", which
+// reaches monitoring with no stack, no URL and no boot phase. Name the asset
+// and the phase so the report is actionable.
+export async function fetchBootAsset(url, init, phase) {
+  try {
+    return await fetch(url, init);
+  } catch (error) {
+    // Drop the query string: cache-busting params would fragment grouping.
+    const target = String(url).split("?")[0];
+    throw new Error(
+      `Network error while fetching ${phase} (${target}): ${error?.message || error}`,
+      { cause: error },
+    );
+  }
+}
+
 /**
  * Download a resource with streaming progress reporting.
  */
-export async function fetchWithProgress(url, onProgress) {
-  const response = await fetch(url);
+export async function fetchWithProgress(url, onProgress, phase = "asset") {
+  const response = await fetchBootAsset(url, undefined, phase);
   if (!response.ok) {
     throw new Error(`Failed to fetch ${url}: ${response.status}`);
   }
@@ -56,7 +73,7 @@ export async function fetchWithProgress(url, onProgress) {
  */
 export async function fetchManifest(manifestUrl) {
   const url = manifestUrl || DEFAULT_MANIFEST_URL;
-  const response = await fetch(url, { cache: "no-cache" });
+  const response = await fetchBootAsset(url, { cache: "no-cache" }, "manifest");
   if (!response.ok) {
     throw new Error(`Unable to load manifest: ${response.status}`);
   }
@@ -120,7 +137,7 @@ export async function fetchBundleWithCache(manifest, onProgress) {
     }
   }
 
-  const bytes = await fetchWithProgress(url, onProgress);
+  const bytes = await fetchWithProgress(url, onProgress, "core bundle");
 
   if (expectedSha) {
     const actual = await sha256Hex(bytes);

--- a/scripts/zip-proxy-worker.js
+++ b/scripts/zip-proxy-worker.js
@@ -231,14 +231,7 @@ async function handleAtomFeed(repo, type) {
     );
 
     if (!upstream.ok) {
-      return jsonResponse(
-        {
-          error: "Upstream server returned an error.",
-          status: upstream.status,
-          statusText: upstream.statusText,
-        },
-        502,
-      );
+      return upstreamErrorResponse(upstream);
     }
 
     const headers = new Headers();
@@ -282,14 +275,7 @@ async function proxyRawFile(repo, ref, rawPath) {
     );
 
     if (!upstream.ok) {
-      return jsonResponse(
-        {
-          error: "Upstream server returned an error.",
-          status: upstream.status,
-          statusText: upstream.statusText,
-        },
-        upstream.status === 404 ? 404 : 502,
-      );
+      return upstreamErrorResponse(upstream);
     }
 
     const headers = new Headers();
@@ -638,15 +624,7 @@ async function proxyGitHubZip(
     );
 
     if (!upstream.ok) {
-      return jsonResponse(
-        {
-          error: "Upstream server returned an error.",
-          status: upstream.status,
-          statusText: upstream.statusText,
-          upstream_url: url,
-        },
-        502,
-      );
+      return upstreamErrorResponse(upstream, { upstream_url: url });
     }
 
     const responseHeaders = new Headers(upstream.headers);
@@ -748,14 +726,7 @@ async function handleGenericProxy(targetUrl, request) {
     );
 
     if (!upstream.ok) {
-      return jsonResponse(
-        {
-          error: "Upstream server returned an error.",
-          status: upstream.status,
-          statusText: upstream.statusText,
-        },
-        502,
-      );
+      return upstreamErrorResponse(upstream);
     }
 
     const headers = new Headers(upstream.headers);
@@ -819,6 +790,25 @@ function jsonResponse(data, status) {
       ...corsHeaders(),
     },
   });
+}
+
+// Maps an upstream failure onto a client-visible status. A 404 (deleted branch,
+// renamed repo, stale blueprint URL), a 403/429 (rate limit) and a 401 are the
+// upstream's own verdict, not a proxy outage, so they are passed through instead
+// of being flattened into 502 — reporting them as "bad gateway" made ordinary
+// "not found" errors look like the proxy itself was down.
+const PASSTHROUGH_UPSTREAM_STATUSES = new Set([401, 403, 404, 410, 429]);
+
+function upstreamErrorResponse(upstream, extra = {}) {
+  return jsonResponse(
+    {
+      error: "Upstream server returned an error.",
+      status: upstream.status,
+      statusText: upstream.statusText,
+      ...extra,
+    },
+    PASSTHROUGH_UPSTREAM_STATUSES.has(upstream.status) ? upstream.status : 502,
+  );
 }
 
 // Maps a blocked redirect into a 400 response. A redirect into an

--- a/src/remote/main.js
+++ b/src/remote/main.js
@@ -4,9 +4,14 @@ import { loadPlaygroundConfig } from "../shared/config.js";
 import { resolveRuntimeConfig } from "../shared/omeka-versions.js";
 import { buildScopedSitePath } from "../shared/paths.js";
 import { createShellChannel } from "../shared/protocol.js";
+import {
+  createServiceWorkerUnsupportedError,
+  isServiceWorkerSupported,
+} from "../shared/service-worker-support.js";
 import { saveSessionState } from "../shared/storage.js";
 
 const overlayEl = document.querySelector(".remote-boot__card");
+const titleEl = document.querySelector("#remote-title");
 const statusEl = document.querySelector("#remote-status");
 const frameEl = document.querySelector("#remote-frame");
 const progressFillEl = document.querySelector("#progress-fill");
@@ -48,7 +53,13 @@ function emit(scopeId, message) {
 }
 
 async function registerRuntimeServiceWorker(scopeId, runtimeId, config) {
-  if (navigator.serviceWorker.controller) {
+  // Checked before any property access: in iOS Safari private browsing (and
+  // any insecure context) navigator.serviceWorker does not exist at all.
+  if (!isServiceWorkerSupported()) {
+    throw createServiceWorkerUnsupportedError();
+  }
+
+  if (navigator.serviceWorker?.controller) {
     return navigator.serviceWorker.ready;
   }
 
@@ -63,18 +74,21 @@ async function registerRuntimeServiceWorker(scopeId, runtimeId, config) {
     updateViaCache: "none",
   });
 
-  await navigator.serviceWorker.ready;
+  await navigator.serviceWorker?.ready;
   return registration;
 }
 
 async function waitForServiceWorkerControl() {
-  if (!navigator.serviceWorker.controller) {
-    await new Promise((resolve) => {
-      navigator.serviceWorker.addEventListener("controllerchange", resolve, {
-        once: true,
-      });
-    });
+  // Read the container once: with no container there is nothing to wait for,
+  // and awaiting a listener that can never fire would hang the boot forever.
+  const container = navigator.serviceWorker;
+  if (!container || container.controller) {
+    return;
   }
+
+  await new Promise((resolve) => {
+    container.addEventListener("controllerchange", resolve, { once: true });
+  });
 }
 
 async function waitForPhpWorkerReady(scopeId, runtimeId, worker) {
@@ -239,12 +253,10 @@ async function bootstrapRemote() {
   await waitForServiceWorkerControl();
   setRemoteProgress("Service Worker ready and controlling this tab.", 0.12);
 
-  if (navigator.serviceWorker.controller) {
-    navigator.serviceWorker.controller.postMessage({
-      kind: "configure-service-worker",
-      addonProxyUrl: config.addonProxyUrl || null,
-    });
-  }
+  navigator.serviceWorker?.controller?.postMessage({
+    kind: "configure-service-worker",
+    addonProxyUrl: config.addonProxyUrl || null,
+  });
 
   if (!phpWorker) {
     const workerUrl = new URL(
@@ -320,9 +332,17 @@ bootstrapRemote().catch((error) => {
   const url = new URL(window.location.href);
   const scopeId = url.searchParams.get("scope");
   setOverlayVisible(true);
+  // The overlay is the only thing the user sees here, so relabel it: leaving
+  // "Preparing…" above a failure message reads as a boot still in progress.
+  if (titleEl) {
+    titleEl.textContent = "The playground cannot start";
+  }
   setRemoteProgress(String(error?.message || error));
   emit(scopeId, {
     kind: "error",
+    // The shell owns the monitoring client; the error name lets it tell an
+    // unsupported browser apart from a genuine runtime failure.
+    errorName: error?.name || "Error",
     detail: String(error?.stack || error?.message || error),
   });
 });

--- a/src/runtime/manifest.js
+++ b/src/runtime/manifest.js
@@ -1,3 +1,4 @@
+import { fetchBootAsset } from "../../lib/omeka-loader.js";
 import {
   buildManifestFilename,
   DEFAULT_OMEKA_VERSION,
@@ -11,7 +12,13 @@ export function buildManifestUrl(omekaVersion) {
 
 export async function fetchManifest({ omekaVersion } = {}) {
   const versioned = buildManifestUrl(omekaVersion);
-  const response = await fetch(versioned, { cache: "no-cache" });
+  // This is the first request of the whole boot, so a network-level rejection
+  // here is the one most likely to reach monitoring — name the phase.
+  const response = await fetchBootAsset(
+    versioned,
+    { cache: "no-cache" },
+    "manifest",
+  );
   if (response.ok) {
     const manifest = await response.json();
     manifest._manifestUrl = versioned.toString();
@@ -25,7 +32,11 @@ export async function fetchManifest({ omekaVersion } = {}) {
   // Fall back to the legacy default manifest for installs that haven't
   // regenerated per-version assets yet.
   const fallback = resolveProjectUrl("assets/manifests/latest.json");
-  const fallbackResponse = await fetch(fallback, { cache: "no-cache" });
+  const fallbackResponse = await fetchBootAsset(
+    fallback,
+    { cache: "no-cache" },
+    "manifest fallback",
+  );
   if (!fallbackResponse.ok) {
     throw new Error(
       `Unable to load Omeka manifest (version=${omekaVersion || "default"}): ${response.status}`,

--- a/src/runtime/php-compat.js
+++ b/src/runtime/php-compat.js
@@ -89,20 +89,40 @@ function getMimeType(path) {
   return MIME_TYPES[ext] || "application/octet-stream";
 }
 
-function phpResponseToResponse(phpResponse) {
+// The Fetch spec forbids a body on these statuses; PHP legitimately emits 204
+// and 304 (conditional GETs, no-content replies) and constructing a Response
+// with bytes for them throws and blanks the whole page.
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
+export function phpResponseToResponse(phpResponse) {
   const headers = new Headers();
   if (phpResponse.headers) {
     for (const [key, values] of Object.entries(phpResponse.headers)) {
       for (const value of values) {
-        headers.append(key, value);
+        // Skip headers with an invalid name/value rather than letting a single
+        // malformed header (Headers.append() throws "Invalid name") abort the
+        // entire response — which would blank the whole page.
+        try {
+          headers.append(key, value);
+        } catch (error) {
+          try {
+            console.warn(
+              `[php-compat] skipping invalid response header "${key}": ${error?.message || error}`,
+            );
+          } catch {}
+        }
       }
     }
   }
 
-  return new Response(phpResponse.bytes, {
-    status: phpResponse.httpStatusCode,
-    headers,
-  });
+  const status = phpResponse.httpStatusCode;
+  return new Response(
+    NULL_BODY_STATUSES.has(status) ? null : phpResponse.bytes,
+    {
+      status,
+      headers,
+    },
+  );
 }
 
 /**

--- a/src/shared/service-worker-support.js
+++ b/src/shared/service-worker-support.js
@@ -1,0 +1,42 @@
+// Guard for the one browser capability the playground cannot do without.
+//
+// `navigator.serviceWorker` is simply absent in iOS Safari private browsing,
+// in insecure (non-HTTPS) contexts, and whenever a browser has Service
+// Workers disabled. Reading `.register` / `.addEventListener` off it there
+// throws "undefined is not an object" before anything renders, so the user
+// gets a blank page instead of an explanation. Every entry point checks this
+// first and reports the limitation itself.
+
+export const SERVICE_WORKER_UNSUPPORTED_ERROR_NAME =
+  "ServiceWorkerUnsupportedError";
+
+export const SERVICE_WORKER_UNSUPPORTED_MESSAGE =
+  "Service Workers are unavailable in this browser context. Private browsing " +
+  "on iOS Safari disables them, and the playground cannot run without one.";
+
+/**
+ * True when this context can register a Service Worker. Takes the navigator
+ * to inspect so it stays a pure function (and testable outside a browser).
+ */
+export function isServiceWorkerSupported(navigatorLike = globalThis.navigator) {
+  return (
+    typeof navigatorLike === "object" &&
+    navigatorLike !== null &&
+    "serviceWorker" in navigatorLike &&
+    typeof navigatorLike.serviceWorker?.register === "function"
+  );
+}
+
+/**
+ * The error thrown at every registration site when the API is missing. Named
+ * so callers can tell an environment limitation apart from a real failure.
+ */
+export function createServiceWorkerUnsupportedError() {
+  const error = new Error(SERVICE_WORKER_UNSUPPORTED_MESSAGE);
+  error.name = SERVICE_WORKER_UNSUPPORTED_ERROR_NAME;
+  return error;
+}
+
+export function isServiceWorkerUnsupportedError(error) {
+  return error?.name === SERVICE_WORKER_UNSUPPORTED_ERROR_NAME;
+}

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -28,6 +28,13 @@ import {
 } from "../shared/paths.js";
 import { createShellChannel } from "../shared/protocol.js";
 import {
+  createServiceWorkerUnsupportedError,
+  isServiceWorkerSupported,
+  isServiceWorkerUnsupportedError,
+  SERVICE_WORKER_UNSUPPORTED_ERROR_NAME,
+  SERVICE_WORKER_UNSUPPORTED_MESSAGE,
+} from "../shared/service-worker-support.js";
+import {
   clearScopeSession,
   getOrCreateScopeId,
   loadSessionState,
@@ -157,6 +164,12 @@ async function ensureRuntimeServiceWorker() {
     return;
   }
 
+  // Bail out before touching navigator.serviceWorker: reading .register off
+  // an undefined property is the crash we are avoiding, not a fallback.
+  if (!isServiceWorkerSupported()) {
+    throw createServiceWorkerUnsupportedError();
+  }
+
   const swUrl = new URL("../../sw.js", import.meta.url);
   // Cache-bust the SW by the per-build worker-bundle hash so a redeploy is
   // always picked up (the old static config.bundleVersion was manual).
@@ -170,9 +183,9 @@ async function ensureRuntimeServiceWorker() {
     updateViaCache: "none",
   });
   await registration.update();
-  await navigator.serviceWorker.ready;
+  await navigator.serviceWorker?.ready;
 
-  if (!navigator.serviceWorker.controller) {
+  if (!navigator.serviceWorker?.controller) {
     const alreadyReloaded =
       window.sessionStorage.getItem(CONTROL_RELOAD_KEY) === "1";
     if (!alreadyReloaded) {
@@ -190,7 +203,16 @@ async function updateFrame() {
     serviceWorkerReady = ensureRuntimeServiceWorker();
   }
 
-  await serviceWorkerReady;
+  try {
+    await serviceWorkerReady;
+  } catch (error) {
+    // Without a Service Worker nothing downstream can load, so stop here and
+    // explain why instead of pointing the iframe at a route nobody serves.
+    serviceWorkerReady = null;
+    reportServiceWorkerFailure(error);
+    return;
+  }
+
   const url = resolveRemoteUrl(scopeId, currentRuntimeId, currentPath);
   if (pendingCleanBoot) {
     url.searchParams.set("clean", "1");
@@ -199,8 +221,67 @@ async function updateFrame() {
     url.searchParams.set("reload", String(remoteReloadToken));
   }
   remoteFrameBooted = false;
+  // srcdoc wins over src, so a previously rendered error page has to go
+  // before a retry can load the runtime again.
+  els.frame.removeAttribute("srcdoc");
   els.frame.src = url.toString();
   pendingCleanBoot = false;
+}
+
+function reportServiceWorkerFailure(error) {
+  if (isServiceWorkerUnsupportedError(error)) {
+    // An environment limitation, not a regression: report it as a warning
+    // under its own source so it groups apart from real runtime failures.
+    captureMessage(SERVICE_WORKER_UNSUPPORTED_MESSAGE, "warning", {
+      source: "service-worker-unsupported",
+    });
+    showBlockingError(SERVICE_WORKER_UNSUPPORTED_MESSAGE);
+    return;
+  }
+
+  captureException(error, { source: "service-worker-registration" });
+  showBlockingError(
+    `The playground could not register its Service Worker: ${
+      error?.message || error
+    }`,
+  );
+}
+
+/**
+ * Surface a fatal boot failure where the user is actually looking. The log
+ * panel starts collapsed, so logging alone leaves an unexplained blank frame.
+ */
+function showBlockingError(message) {
+  appendLog(message, true);
+  setUiLocked(false);
+  setActivePanel("logs");
+  expandSidePanel();
+
+  if (els.frame) {
+    els.frame.removeAttribute("src");
+    els.frame.srcdoc = `<!doctype html><meta charset="utf-8"><style>
+      html,body{height:100%}
+      body{margin:0;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box;background:#fff;color:#1f2937;font:15px/1.6 ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+      div{max-width:44ch;text-align:center}
+      strong{display:block;margin-bottom:8px;font-size:17px}
+    </style><div role="alert"><strong>The playground cannot start</strong>${escapeHtml(
+      message,
+    )}</div>`;
+  }
+}
+
+function expandSidePanel() {
+  els.sidePanel.classList.remove("is-collapsed");
+  els.workspace.classList.remove("is-panel-collapsed");
+  els.panelToggle.setAttribute("aria-expanded", "true");
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
 }
 
 function postToRemote(message) {
@@ -436,7 +517,16 @@ function bindShellChannel() {
         remoteFrameBooted = false;
         setUiLocked(false);
         appendLog(message.detail, true);
-        captureMessage(message.detail, "error", { source: "runtime" });
+        if (message.errorName === SERVICE_WORKER_UNSUPPORTED_ERROR_NAME) {
+          // Reported by the remote host, which has no monitoring client of
+          // its own. Same classification as the shell-side check: a warning
+          // on its own source, not a runtime error.
+          captureMessage(SERVICE_WORKER_UNSUPPORTED_MESSAGE, "warning", {
+            source: "service-worker-unsupported",
+          });
+        } else {
+          captureMessage(message.detail, "error", { source: "runtime" });
+        }
         if (!latestPhpInfoHtml) {
           capturePhpInfoViaWorker("bootstrap-error");
         }
@@ -455,7 +545,7 @@ function bindShellChannel() {
 }
 
 function bindServiceWorkerMessages() {
-  navigator.serviceWorker.addEventListener("message", (event) => {
+  navigator.serviceWorker?.addEventListener("message", (event) => {
     const message = event.data;
     if (message?.kind === "sw-debug") {
       appendLog(`[sw] ${message.detail}`);

--- a/tests/omeka-loader.test.mjs
+++ b/tests/omeka-loader.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { strToU8, zipSync } from "fflate";
-import { sanitizeArchivePath, streamZipEntries } from "../lib/omeka-loader.js";
+import {
+  fetchBootAsset,
+  sanitizeArchivePath,
+  streamZipEntries,
+} from "../lib/omeka-loader.js";
 
 function buildSampleZip() {
   // A nested file, a directory entry, and a crafted ZIP-slip entry.
@@ -46,5 +50,52 @@ describe("streamZipEntries", () => {
     assert.ok(names.includes("index.php"));
     assert.ok(names.includes("application/Module.php"));
     assert.ok(names.includes("../evil.php"));
+  });
+});
+
+describe("fetchBootAsset", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("names the boot phase and the query-less URL on a network failure", async () => {
+    // What WebKit and Firefox actually throw: a bare message, no URL, no phase.
+    globalThis.fetch = async () => {
+      throw new TypeError("Load failed");
+    };
+
+    await assert.rejects(
+      fetchBootAsset(
+        "https://example.test/assets/manifests/4.1.1.json?v=abc123",
+        { cache: "no-cache" },
+        "manifest",
+      ),
+      (error) => {
+        assert.match(error.message, /manifest/u);
+        assert.match(
+          error.message,
+          /https:\/\/example\.test\/assets\/manifests\/4\.1\.1\.json/u,
+        );
+        // The cache-busting param would fragment Sentry grouping.
+        assert.ok(!error.message.includes("v=abc123"));
+        assert.match(error.message, /Load failed/u);
+        assert.ok(error.cause instanceof TypeError);
+        return true;
+      },
+    );
+  });
+
+  it("passes the response through untouched when the fetch resolves", async () => {
+    const expected = new Response("ok", { status: 200 });
+    globalThis.fetch = async () => expected;
+
+    const response = await fetchBootAsset(
+      "https://example.test/x",
+      undefined,
+      "asset",
+    );
+    assert.equal(response, expected);
   });
 });

--- a/tests/php-compat-response.test.mjs
+++ b/tests/php-compat-response.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { phpResponseToResponse } from "../src/runtime/php-compat.js";
+
+const BODY = new TextEncoder().encode("<html>hello</html>");
+
+function phpResponse(httpStatusCode, headers = {}, bytes = BODY) {
+  return { httpStatusCode, headers, bytes };
+}
+
+describe("phpResponseToResponse null-body statuses", () => {
+  it("drops the body on 204 so the Response can be constructed", () => {
+    const response = phpResponseToResponse(
+      phpResponse(204, { "content-type": ["text/html"] }),
+    );
+    assert.equal(response.status, 204);
+    assert.equal(response.body, null);
+    assert.equal(response.headers.get("content-type"), "text/html");
+  });
+
+  it("drops the body on 304 (conditional GET)", () => {
+    const response = phpResponseToResponse(
+      phpResponse(304, { etag: ['"abc"'] }),
+    );
+    assert.equal(response.status, 304);
+    assert.equal(response.body, null);
+    assert.equal(response.headers.get("etag"), '"abc"');
+  });
+
+  it("drops the body on 205", () => {
+    // 101 and 103 are in the spec's null-body list too, but the Response
+    // constructor rejects any status below 200 outright, so they are not
+    // representable here.
+    const response = phpResponseToResponse(phpResponse(205));
+    assert.equal(response.status, 205);
+    assert.equal(response.body, null);
+  });
+
+  it("still carries the body on 200", async () => {
+    const response = phpResponseToResponse(
+      phpResponse(200, { "content-type": ["text/html"] }),
+    );
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "<html>hello</html>");
+  });
+});
+
+describe("phpResponseToResponse invalid headers", () => {
+  it("skips a malformed header name and keeps the rest of the response", async () => {
+    const response = phpResponseToResponse(
+      phpResponse(200, {
+        // A space is illegal in a header name; Headers.append() throws
+        // "Invalid name" on it.
+        "X Invalid Name": ["boom"],
+        "content-type": ["text/html"],
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "text/html");
+    // Headers.get() validates the name too, so assert over the kept keys.
+    assert.deepEqual([...response.headers.keys()], ["content-type"]);
+    assert.equal(await response.text(), "<html>hello</html>");
+  });
+
+  it("skips a malformed header value without aborting the response", () => {
+    const response = phpResponseToResponse(
+      phpResponse(200, { "x-broken": ["bad\nvalue"], "x-ok": ["fine"] }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-ok"), "fine");
+    assert.equal(response.headers.get("x-broken"), null);
+  });
+});

--- a/tests/runtime-manifest.test.mjs
+++ b/tests/runtime-manifest.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { buildManifestUrl, fetchManifest } from "../src/runtime/manifest.js";
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchManifest boot fetches", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("names the 'manifest' phase when the versioned fetch fails at the network layer", async () => {
+    // What WebKit and Firefox actually throw: a bare message, no URL, no phase.
+    globalThis.fetch = async () => {
+      throw new TypeError("Load failed");
+    };
+
+    await assert.rejects(fetchManifest({ omekaVersion: "4.1.1" }), (error) => {
+      assert.match(error.message, /Network error while fetching manifest \(/u);
+      assert.ok(!error.message.includes("manifest fallback"));
+      assert.match(error.message, /assets\/manifests\//u);
+      assert.match(error.message, /Load failed/u);
+      assert.ok(error.cause instanceof TypeError);
+      return true;
+    });
+  });
+
+  it("names the 'manifest fallback' phase when the fallback fetch fails", async () => {
+    // A KNOWN version, so the versioned URL is 4.1.1.json and the fallback is
+    // a distinct request: an unknown version already resolves to latest.json.
+    globalThis.fetch = async (url) => {
+      if (!String(url).endsWith("latest.json")) {
+        // The versioned manifest 404s, which is what triggers the fallback.
+        return jsonResponse({ error: "missing" }, 404);
+      }
+      throw new TypeError("NetworkError when attempting to fetch resource.");
+    };
+
+    await assert.rejects(fetchManifest({ omekaVersion: "4.1.1" }), (error) => {
+      assert.match(
+        error.message,
+        /Network error while fetching manifest fallback \(/u,
+      );
+      assert.match(error.message, /assets\/manifests\/latest\.json/u);
+      assert.match(error.message, /NetworkError/u);
+      return true;
+    });
+  });
+
+  it("strips the query string from the reported URL", async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError("Load failed");
+    };
+
+    await assert.rejects(fetchManifest({ omekaVersion: "4.1.1" }), (error) => {
+      // Cache-busting params would fragment Sentry grouping.
+      assert.ok(!error.message.includes("?"));
+      return true;
+    });
+  });
+
+  it("still resolves the versioned manifest when the network is healthy", async () => {
+    globalThis.fetch = async () => jsonResponse({ release: "4.1.1" });
+
+    const manifest = await fetchManifest({ omekaVersion: "4.1.1" });
+    assert.equal(manifest.release, "4.1.1");
+    assert.equal(
+      manifest._manifestUrl,
+      buildManifestUrl("4.1.1").toString(),
+      "the versioned URL is still recorded on the manifest",
+    );
+  });
+
+  it("still falls back to latest.json on a 404", async () => {
+    globalThis.fetch = async (url) =>
+      String(url).endsWith("latest.json")
+        ? jsonResponse({ release: "legacy" })
+        : jsonResponse({ error: "missing" }, 404);
+
+    const manifest = await fetchManifest({ omekaVersion: "4.1.1" });
+    assert.equal(manifest.release, "legacy");
+    assert.match(manifest._manifestUrl, /assets\/manifests\/latest\.json$/u);
+  });
+
+  it("still surfaces a non-404 HTTP status without the network wrapper", async () => {
+    globalThis.fetch = async () => jsonResponse({ error: "boom" }, 500);
+
+    await assert.rejects(fetchManifest({ omekaVersion: "4.1.1" }), (error) => {
+      assert.equal(error.message, "Unable to load Omeka manifest: 500");
+      return true;
+    });
+  });
+});

--- a/tests/service-worker-support.test.mjs
+++ b/tests/service-worker-support.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  createServiceWorkerUnsupportedError,
+  isServiceWorkerSupported,
+  isServiceWorkerUnsupportedError,
+  SERVICE_WORKER_UNSUPPORTED_ERROR_NAME,
+  SERVICE_WORKER_UNSUPPORTED_MESSAGE,
+} from "../src/shared/service-worker-support.js";
+
+describe("isServiceWorkerSupported", () => {
+  it("accepts a navigator exposing a registerable container", () => {
+    assert.equal(
+      isServiceWorkerSupported({ serviceWorker: { register() {} } }),
+      true,
+    );
+  });
+
+  it("rejects a navigator without the API (iOS Safari private browsing)", () => {
+    assert.equal(isServiceWorkerSupported({}), false);
+  });
+
+  it("rejects a present-but-unusable container", () => {
+    // Insecure contexts can expose the property with nothing behind it.
+    assert.equal(isServiceWorkerSupported({ serviceWorker: undefined }), false);
+    assert.equal(isServiceWorkerSupported({ serviceWorker: null }), false);
+    assert.equal(isServiceWorkerSupported({ serviceWorker: {} }), false);
+    assert.equal(
+      isServiceWorkerSupported({ serviceWorker: { register: "nope" } }),
+      false,
+    );
+  });
+
+  it("rejects a missing navigator without throwing", () => {
+    assert.equal(isServiceWorkerSupported(undefined), false);
+    assert.equal(isServiceWorkerSupported(null), false);
+  });
+});
+
+describe("createServiceWorkerUnsupportedError", () => {
+  it("carries a stable name and a human-readable message", () => {
+    const error = createServiceWorkerUnsupportedError();
+    assert.ok(error instanceof Error);
+    assert.equal(error.name, SERVICE_WORKER_UNSUPPORTED_ERROR_NAME);
+    assert.equal(error.name, "ServiceWorkerUnsupportedError");
+    assert.equal(error.message, SERVICE_WORKER_UNSUPPORTED_MESSAGE);
+    assert.match(error.message, /Private browsing on iOS Safari/u);
+  });
+});
+
+describe("isServiceWorkerUnsupportedError", () => {
+  it("distinguishes the unsupported error from a rejected registration", () => {
+    assert.equal(
+      isServiceWorkerUnsupportedError(createServiceWorkerUnsupportedError()),
+      true,
+    );
+    assert.equal(isServiceWorkerUnsupportedError(new Error("Rejected")), false);
+    assert.equal(isServiceWorkerUnsupportedError(undefined), false);
+    assert.equal(isServiceWorkerUnsupportedError("Rejected"), false);
+  });
+});


### PR DESCRIPTION
Preventive hardening for five failure modes. `omeka-s-playground` has **no real Sentry errors of its own yet** (only resolved smoke tests), but it shares its runtime code almost verbatim with the three sibling playgrounds, where each of these fired in production. Each fix below names the sibling the evidence came from.

## Fix A — Service Worker API missing / registration rejected

**Sentry (moodle-playground, production):**
- `TypeError: undefined is not an object (evaluating 'navigator.serviceWorker.register')` — Mobile Safari 26.6 / iOS 18.7
- `TypeError: undefined is not an object (evaluating 'navigator.serviceWorker.addEventListener')`
- `Error: Rejected` — Chrome 151 / Windows, same registration path

**Root cause:** the shell (`src/shell/main.js:167`) and the remote host (`src/remote/main.js:60`) read `navigator.serviceWorker` unconditionally. In iOS Safari **private browsing**, in insecure contexts, and wherever Service Workers are disabled, the property is `undefined`, so the first property access throws before anything renders. This repo had no optional chaining anywhere on that path — `src/shell/main.js:458` was fully unguarded. A *rejected* `register()` produced the same blank page.

**Fix:**
- New `src/shared/service-worker-support.js` with the pure helper `isServiceWorkerSupported(navigatorLike)`, plus `createServiceWorkerUnsupportedError()` (`error.name = "ServiceWorkerUnsupportedError"`) and `isServiceWorkerUnsupportedError()`.
- Both registration sites check first and throw the named error without touching `navigator.serviceWorker`.
- The shell catches it in `updateFrame()` and renders a blocking `role="alert"` page in the site frame, appends the message to the runtime log, opens the Logs panel and unlocks the toolbar so a retry is possible. The remote host relabels its boot overlay to "The playground cannot start" and shows the message.
- Monitoring: unsupported browser → `captureMessage(message, "warning", { source: "service-worker-unsupported" })`; a genuinely rejected `register()` → `captureException(error, { source: "service-worker-registration" })`. The remote host has no monitoring client of its own, so it forwards `errorName` on its `kind: "error"` channel message and the shell classifies it the same way.
- Every other `navigator.serviceWorker.*` access on the boot path is now null-safe. `waitForServiceWorkerControl()` returns early instead of awaiting a `controllerchange` listener that could never fire (optional chaining alone would have turned the crash into a permanent hang).
- `updateFrame()` clears `srcdoc` before setting `src`, since `srcdoc` wins and would otherwise pin the error page in place after a retry.

**Test:** `tests/service-worker-support.test.mjs` — 6 tests over the pure helpers (present/absent/unusable container, missing navigator, stable error name and message, unsupported vs. rejected discrimination). The DOM-heavy shell is not unit-tested.

## Fix B — `TypeError: Response with null body status cannot have body`

**Sentry (nextcloud-playground, production, 2 events / 2 users, Chrome/macOS):**
```
TypeError: Response with null body status cannot have body
    at phpResponseToResponse (dist/php-worker.bundle.js)
```

**Root cause:** `src/runtime/php-compat.js` built `new Response(phpResponse.bytes, { status: phpResponse.httpStatusCode, ... })`. The Fetch spec forbids a body on null-body statuses, and PHP legitimately emits 204/304 (conditional GETs, no-content replies), so the constructor threw and blanked the page.

**Fix:** a module-level `NULL_BODY_STATUSES` set (101, 103, 204, 205, 304); the body is passed as `null` for those statuses.

**Test:** `tests/php-compat-response.test.mjs` — 204, 304 and 205 with non-empty `bytes` produce a valid `Response` with the right status, no body and intact headers; 200 still carries the body. (101/103 are in the spec's list but are not representable at all — the `Response` constructor rejects any status below 200 — so the set keeps them for spec parity while the test covers what can be constructed.)

## Fix C — an invalid response header aborts the whole response

**Root cause:** `headers.append(key, value)` in `phpResponseToResponse` throws `Invalid name` on a malformed header emitted by PHP, aborting the entire response and blanking the page. `nextcloud-playground` already carried this guard; this repo did not.

**Fix:** the `append` is wrapped in a `try`/`catch` that skips the offending header and warns, matching the sibling's implementation exactly.

**Test:** `tests/php-compat-response.test.mjs` — a malformed header *name* and a malformed header *value* are each skipped while the rest of the headers and the body survive.

## Fix D — proxy worker reports an upstream 404 as 502

**Sentry (facturascripts-playground, production):** the shared proxy returned **502** with body `{"error":"Upstream server returned an error.","status":404,...}` for a GitHub archive URL whose branch had been deleted; a control URL returned 200. The proxy was healthy — it just masked "not found" as "bad gateway". The request was served by this repo's `zip-proxy` worker.

**Fix:** `scripts/zip-proxy-worker.js` gains `PASSTHROUGH_UPSTREAM_STATUSES` (401, 403, 404, 410, 429) and an `upstreamErrorResponse(upstream, extra)` helper placed immediately after `jsonResponse()`. All four `if (!upstream.ok)` blocks now delegate to it, preserving the ZIP path's `upstream_url` field; the helper subsumes the one block that already special-cased 404. Nothing else in the file was touched.

**Mirror note:** this file is a synced mirror of moodle-playground's canonical `scripts/github-proxy-worker.js`. This change adds **zero** new divergence: `diff` between the two files is 19 lines both before and after, and the `upstreamErrorResponse` block is byte-identical to the canonical one. The 19 lines are this repo's own 6-line "SYNCED MIRROR" header (unchanged) plus three **pre-existing** example strings in comments and the landing page (`epubviewer-*.tar.gz` here vs `package-*.tar.gz` upstream) that predate this PR and were deliberately left alone. The worker's unit test lives only in moodle-playground, so no test is added here.

## Fix E — boot fetch failures reach Sentry with no context

**Sentry (moodle-playground, production):** `Load failed` (Safari 26.5.2 / macOS and Chrome Mobile iOS 152, 2 users, both WebKit) and `NetworkError when attempting to fetch resource.` (Firefox 153) — the generic browser message for a `fetch()` that rejects at the network layer, arriving as a bare string with no stack, no URL and no boot phase, so it is unactionable.

**Root cause:** in `lib/omeka-loader.js` the HTTP-status failures already threw good messages, but a network-level rejection propagated the raw `TypeError`.

**Fix:** a new `fetchBootAsset(url, init, phase)` in `lib/omeka-loader.js` wraps `fetch()` and rethrows as `Network error while fetching <phase> (<url>): <original>` with `{ cause }`. The query string is stripped so cache-busting params do not fragment Sentry grouping. **All four** boot fetches now route through it, each with a distinct stable phase label:

| File | Call | Phase |
|---|---|---|
| `lib/omeka-loader.js` | `fetchManifest()` | `"manifest"` |
| `lib/omeka-loader.js` | `fetchBundleWithCache()` via `fetchWithProgress()` | `"core bundle"` |
| `src/runtime/manifest.js` | versioned manifest | `"manifest"` |
| `src/runtime/manifest.js` | `latest.json` fallback | `"manifest fallback"` |

`src/runtime/manifest.js` matters most here: its versioned-manifest request is the **first request of the whole boot**, so it is the one most likely to be the source of the reported `Load failed`. The fallback gets its own label so the two are distinguishable in Sentry.

**Tests:**
- `tests/omeka-loader.test.mjs` — a rejecting `fetch` yields a message containing the phase and the query-less URL (and not the cache-busting param), with the original error preserved as `cause`; a resolving `fetch` is passed through untouched.
- `tests/runtime-manifest.test.mjs` (new, 6 tests) — the versioned failure reports phase `"manifest"` and the fallback failure reports phase `"manifest fallback"`; the query string is stripped; and the three unwrapped behaviours are pinned as regressions (a healthy versioned fetch still resolves and records `_manifestUrl`, a 404 still falls back to `latest.json`, and a non-404 HTTP status still throws `Unable to load Omeka manifest: 500` rather than the network wrapper).

## Verification

```
$ npm test
ℹ tests 234
ℹ suites 60
ℹ pass 234
ℹ fail 0

$ npx @biomejs/biome check
Checked 64 files in 213ms. No fixes applied.
Found 4 warnings.
Found 2 infos.
(exit 0 — identical to the baseline on main; no new findings)

$ npm run build-worker
Built dist/php-worker.bundle.js (bundled PHP runtimes: 8-1, 8-2, 8-3, 8-4, 8-5)
```

## Not included

- **The Cloudflare worker is NOT deployed.** `scripts/zip-proxy-worker.js` is only updated in the repo; the `zip-proxy` worker still runs the old code and will keep returning 502 for upstream 404s until it is deployed. Deployment is left for separate approval.
- No ADR was added. These are defect fixes rather than durable architecture decisions; Fix D's status-passthrough contract belongs to the canonical worker in moodle-playground.
